### PR TITLE
feat: add listing a dashboard's related analysis

### DIFF
--- a/src/modules/Account/Dashboards.ts
+++ b/src/modules/Account/Dashboards.ts
@@ -7,6 +7,7 @@ import {
   DashboardInfo,
   DashboardQuery,
   DevicesRelated,
+  AnalysisRelated,
   PublicKeyResponse,
 } from "./dashboards.types";
 import _Share from "./_Share";
@@ -179,6 +180,19 @@ class Dashboards extends TagoIOModule<GenericModuleParams> {
   public async listDevicesRelated(dashboardID: GenericID): Promise<DevicesRelated[]> {
     const result = await this.doRequest<DevicesRelated[]>({
       path: `/dashboard/${dashboardID}/devices`,
+      method: "GET",
+    });
+
+    return result;
+  }
+
+  /**
+   * Get list of analysis related with a dashboard
+   * @param dashboardID Dashboard identification
+   */
+  public async listAnalysisRelated(dashboardID: GenericID): Promise<AnalysisRelated[]> {
+    const result = await this.doRequest<AnalysisRelated[]>({
+      path: `/dashboard/${dashboardID}/analysis`,
       method: "GET",
     });
 

--- a/src/modules/Account/dashboards.types.ts
+++ b/src/modules/Account/dashboards.types.ts
@@ -59,6 +59,11 @@ interface DevicesRelated extends BucketDeviceInfo {
   bucket: GenericID;
 }
 
+interface AnalysisRelated {
+  id: GenericID;
+  name: string;
+}
+
 type DashboardQuery = Query<DashboardInfo, "name" | "label" | "active" | "created_at" | "updated_at">;
 
 type PublicKeyResponse = { token: GenericToken; expire_time: "never" };
@@ -73,6 +78,7 @@ export {
   DashboardQuery,
   PublicKeyResponse,
   DevicesRelated,
+  AnalysisRelated,
   DashboardCreateInfo,
   DashboardInfo,
   WidgetInfo,


### PR DESCRIPTION
This PR adds the functionality to fetch the related analysis of a dashboard from the API.