### PR TITLE
fix: dictionary parsing values enclosed in hashtags

### DIFF
--- a/__tests__/Dictionary/applyToString.ts
+++ b/__tests__/Dictionary/applyToString.ts
@@ -46,6 +46,29 @@ describe("applyToString", () => {
     expect(applied).toEqual("FirstPartandSecondPart");
   });
 
+  it("does not apply the dictionary to a string enclosed in hashtags but no expression", async () => {
+    const singleValue = await dictionary.applyToString("#NOTSLUG#", options);
+    const multiValue = await dictionary.applyToString("#NOTSLUG##HASHTAG#", options);
+    const multiValueSpaced = await dictionary.applyToString("#NOTSLUG# #HASHTAG#", options);
+
+    expect(singleValue).toEqual("#NOTSLUG#");
+    expect(multiValue).toEqual("#NOTSLUG##HASHTAG#");
+    expect(multiValueSpaced).toEqual("#NOTSLUG# #HASHTAG#");
+  });
+
+  it("does not apply the dictionary to a string enclosed in hashtags with wrong expression syntax", async () => {
+    const almostAnExpression = await dictionary.applyToString("#SLUG.#", options);
+    const validSlugInvalidKey = await dictionary.applyToString("#SLUG.invalid_Key#", options);
+    const invalidSlugValidKey = await dictionary.applyToString("#notSlug.VALID_KEY#", options);
+    const slugWithSpaces = await dictionary.applyToString("#SL UG.VALID_KEY#", options);
+    const keyWithSpaces = await dictionary.applyToString("#SLUG.INVALID KEY#", options);
+    expect(almostAnExpression).toEqual("#SLUG.#");
+    expect(validSlugInvalidKey).toEqual("#SLUG.invalid_Key#");
+    expect(invalidSlugValidKey).toEqual("#notSlug.VALID_KEY#");
+    expect(slugWithSpaces).toEqual("#SL UG.VALID_KEY#");
+    expect(keyWithSpaces).toEqual("#SLUG.INVALID KEY#");
+  });
+
   it("applies the dictionary to a big string covering all the dictionary functionality", async () => {
     const rawString =
       "Simple expression first: #TEST.APPLY_ONE#. Then we have a #TEST.BROKEN_EXPRESSION." +

--- a/__tests__/Dictionary/parseExpression.ts
+++ b/__tests__/Dictionary/parseExpression.ts
@@ -36,4 +36,16 @@ describe("parseExpression", () => {
 
     expect(parsed).toEqual({ dictionary: "TEST", key: "TEST_KEY", params: ["a", "bb", "ccc", "ddd#d"] });
   });
+
+  it("does not parse a value enclosed in hashtags but is not an expression, returning null", () => {
+    expect(dictionary.parseExpression("#slug#")).toEqual(null);
+    expect(dictionary.parseExpression("#slug.#")).toEqual(null);
+    expect(dictionary.parseExpression("#slug.lowercase#")).toEqual(null);
+    expect(dictionary.parseExpression("#slug.VALID_KEY#")).toEqual(null);
+    expect(dictionary.parseExpression("#SLUG.#")).toEqual(null);
+    expect(dictionary.parseExpression("#Slug.MIXED_CASE_SLUG#")).toEqual(null);
+    expect(dictionary.parseExpression("#SLUG.Mixed_Case_Key#")).toEqual(null);
+    expect(dictionary.parseExpression("#SLUG.KEY WITH SPACES#")).toEqual(null);
+    expect(dictionary.parseExpression("#S L U G.VALID_KEY#")).toEqual(null);
+  });
 });

--- a/src/modules/Dictionary/Dictionary.ts
+++ b/src/modules/Dictionary/Dictionary.ts
@@ -97,6 +97,8 @@ class Dictionary extends TagoIOModule<IDictionaryModuleParams> {
    * Parse an expression and extract the names of the dictionary, the key, and
    * any arguments that are passed in the expression.
    *
+   * Returns `null` if the value passed is not parseable by the RegEx.
+   *
    * @param expression String expression.
    *
    * @example
@@ -107,6 +109,10 @@ class Dictionary extends TagoIOModule<IDictionaryModuleParams> {
    */
   public parseExpression(expression: string): IParsedExpression {
     const splitExpression = expression.match(RE_MATCH_EXPRESSION);
+    if (!splitExpression) {
+      return null;
+    }
+
     const dictionary = splitExpression[1];
     const keyWithParams = splitExpression[2];
 
@@ -215,6 +221,10 @@ class Dictionary extends TagoIOModule<IDictionaryModuleParams> {
       const isExpression = token.startsWith("#") && token.endsWith("#");
       if (isExpression) {
         const expression = this.parseExpression(token);
+        if (!expression) {
+          return token;
+        }
+
         const { dictionary, key, params } = expression;
 
         return params


### PR DESCRIPTION
This PR fixes an issue where the Dictionary attempted to parse `#something#` when it's the entire string because of the optimization on the splitting checking only for # at the beginning and the end of the split part of a string.

The fix adds a check for the split when parsing an expression to return null if the split RegEx did not match, which then makes `applyToString` simply use the original string instead of crashing when accessing an index that does not exist.

Example: a string like `"#something# test"` would not cause issues because the RegEx splitter would return `["#something# test"]`, and then when checking each item in the split array this one would not start and end with #. However, when the entire string is `#something#` the splitter does not find a RegEx and the split array becomes `["#something#"]` which then fails when parsing.