### PR TITLE
fix: better handle non string values on applyToString

### DIFF
--- a/__tests__/Dictionary/applyToString.ts
+++ b/__tests__/Dictionary/applyToString.ts
@@ -18,11 +18,27 @@ describe("applyToString", () => {
   });
 
   it("does not run if the string is undefined", async () => {
-    const noString = await dictionary.applyToString(undefined, options);
+    const valueUndefined = await dictionary.applyToString(undefined, options);
+    const valueNull = await dictionary.applyToString(null, options);
     const noLanguage = await dictionary.applyToString("Some string", undefined);
 
-    expect(noString).toEqual("");
+    expect(valueUndefined).toStrictEqual("");
+    expect(valueNull).toStrictEqual("");
     expect(noLanguage).toEqual("Some string");
+  });
+
+  it("does not apply if the value passed is not a string", async () => {
+    const valueObject = await dictionary.applyToString({} as any, options);
+    const valueNumber = await dictionary.applyToString(123 as any, options);
+    const valueEmptyArray = await dictionary.applyToString([] as any, options);
+    const valueArray = await dictionary.applyToString([1, 2, 3] as any, options);
+    const valueBoolean = await dictionary.applyToString(true as any, options);
+
+    expect(valueObject).toStrictEqual({});
+    expect(valueNumber).toStrictEqual(123);
+    expect(valueEmptyArray).toStrictEqual([]);
+    expect(valueArray).toStrictEqual([1, 2, 3]);
+    expect(valueBoolean).toStrictEqual(true);
   });
 
   it("does not apply to a string that does not contain hashes", async () => {

--- a/src/modules/Dictionary/Dictionary.ts
+++ b/src/modules/Dictionary/Dictionary.ts
@@ -210,8 +210,10 @@ class Dictionary extends TagoIOModule<IDictionaryModuleParams> {
       return rawString || "";
     }
 
-    // Bail early if there are no variables in the string
-    if (!rawString.includes("#")) {
+    // Bail early if there are no variables in the string or if the value passed
+    // is not a string, which can happen when not using TypeScript or passing the
+    // instance to a function without the type
+    if (typeof rawString !== "string" || !rawString.includes("#")) {
       return rawString;
     }
 


### PR DESCRIPTION
There are at least two cases where `Dictionary.applyToString()` will accept values that are not strings (or `null`/`undefined`), one can be from using the SDK in a JS file which won't have type checking, the other would be passing the Dictionary instance without typing the parameter like this:
```ts
async function applyDictionary(value, dictionary) {
  return dictionary.applyToString(value);
}
```

This PR adds a safeguard in case `applyToString` receives anything other than a string as a value.