### PR TITLE
feat: Added auditLogQuery and auditLogCreate

### DIFF
--- a/src/modules/Account/Profile.ts
+++ b/src/modules/Account/Profile.ts
@@ -11,7 +11,6 @@ import dateParser from "../Utils/dateParser";
 import {
   AddonInfo,
   AuditLog,
-  AuditLogCreateResponse,
   AuditLogFilter,
   ProfileInfo,
   ProfileListInfo,
@@ -130,7 +129,7 @@ class Profile extends TagoIOModule<GenericModuleParams> {
    * @param profileID Profile identification
    * @param filterObj auditlog filter object
    */
-  public async auditLogCreate(profileID: GenericID, filterObj?: AuditLogFilter): Promise<AuditLogCreateResponse> {
+  public async auditLogCreate(profileID: GenericID, filterObj?: AuditLogFilter): Promise<AuditLog> {
     const result = await this.doRequest<AuditLog>({
       path: `/profile/${profileID}/auditlog`,
       method: "GET",

--- a/src/modules/Account/Profile.ts
+++ b/src/modules/Account/Profile.ts
@@ -11,6 +11,7 @@ import dateParser from "../Utils/dateParser";
 import {
   AddonInfo,
   AuditLog,
+  AuditLogCreateResponse,
   AuditLogFilter,
   ProfileInfo,
   ProfileListInfo,
@@ -125,15 +126,30 @@ class Profile extends TagoIOModule<GenericModuleParams> {
   }
 
   /**
-   * Fetches the information from auditlog of this profile
+   * Create a query for auditlog
    * @param profileID Profile identification
    * @param filterObj auditlog filter object
    */
-  public async auditLog(profileID: GenericID, filterObj?: AuditLogFilter): Promise<AuditLog> {
+  public async auditLogCreate(profileID: GenericID, filterObj?: AuditLogFilter): Promise<AuditLogCreateResponse> {
     const result = await this.doRequest<AuditLog>({
       path: `/profile/${profileID}/auditlog`,
       method: "GET",
       params: filterObj || {},
+    });
+
+    result.events = result?.events.map((data) => dateParser(data, ["date"]));
+    return result;
+  }
+
+  /**
+   * Fetches the information from an auditlog query
+   * @param profileID Profile identification
+   * @param queryId auditlog queryId from auditLogCreate
+   */
+  public async auditLogQuery(profileID: GenericID, queryId?: string): Promise<AuditLog> {
+    const result = await this.doRequest<AuditLog>({
+      path: `/profile/${profileID}/auditlog/${queryId}`,
+      method: "GET",
     });
 
     result.events = result?.events.map((data) => dateParser(data, ["date"]));

--- a/src/modules/Account/Profile.ts
+++ b/src/modules/Account/Profile.ts
@@ -129,7 +129,7 @@ class Profile extends TagoIOModule<GenericModuleParams> {
    * @param profileID Profile identification
    * @param filterObj auditlog filter object
    */
-  public async auditLogCreate(profileID: GenericID, filterObj?: AuditLogFilter): Promise<AuditLog> {
+  public async auditLog(profileID: GenericID, filterObj?: AuditLogFilter): Promise<AuditLog> {
     const result = await this.doRequest<AuditLog>({
       path: `/profile/${profileID}/auditlog`,
       method: "GET",

--- a/src/modules/Account/profile.types.ts
+++ b/src/modules/Account/profile.types.ts
@@ -65,30 +65,41 @@ interface UsageStatistic {
 }
 
 interface AuditLog {
-  events: {
+  events?: {
     resourceName: string;
     message: string;
     resourceID: GenericID;
     who: GenericID;
     date: Date;
   }[];
-  statistics: {
+  statistics?: {
     recordsMatched: number;
     recordsScanned: number;
+    bytesScanned: number;
   };
-  status: "Running" | "Complete" | "Failed" | "Timeout" | "Unknown";
+  status?: "Running" | "Complete" | "Failed" | "Timeout" | "Unknown";
   queryId: string;
 }
 
+type resourceNameType =
+  | "action"
+  | "am"
+  | "analysis"
+  | "connector"
+  | "dashboard"
+  | "device"
+  | "dictionary"
+  | "network"
+  | "profile"
+  | "run"
+  | "runuser";
 interface AuditLogFilter {
-  ref_id?: GenericID;
+  resourceID?: GenericID;
+  resourceName?: resourceNameType;
   find?: "*" | string;
   start_date?: Date;
   end_date?: Date;
-}
-
-interface AuditLogCreateResponse {
-  queryId: string;
+  limit?: number;
 }
 
 interface AddonInfo {
@@ -97,13 +108,4 @@ interface AddonInfo {
   logo_url: string | null;
 }
 
-export {
-  ProfileListInfo,
-  ProfileInfo,
-  UsageStatistic,
-  AuditLog,
-  AuditLogCreateResponse,
-  AuditLogFilter,
-  AddonInfo,
-  ProfileSummary,
-};
+export { ProfileListInfo, ProfileInfo, UsageStatistic, AuditLog, AuditLogFilter, AddonInfo, ProfileSummary };

--- a/src/modules/Account/profile.types.ts
+++ b/src/modules/Account/profile.types.ts
@@ -72,19 +72,23 @@ interface AuditLog {
     who: GenericID;
     date: Date;
   }[];
-  searchedLogStreams: {
-    logStreamName: GenericID;
-    searchedCompletely: boolean;
-  }[];
-  nextToken: string;
+  statistics: {
+    recordsMatched: number;
+    recordsScanned: number;
+  };
+  status: "Running" | "Complete" | "Failed" | "Timeout" | "Unknown";
+  queryId: string;
 }
 
 interface AuditLogFilter {
-  nextToken?: string;
   ref_id?: GenericID;
   find?: "*" | string;
   start_date?: Date;
   end_date?: Date;
+}
+
+interface AuditLogCreateResponse {
+  queryId: string;
 }
 
 interface AddonInfo {
@@ -93,4 +97,13 @@ interface AddonInfo {
   logo_url: string | null;
 }
 
-export { ProfileListInfo, ProfileInfo, UsageStatistic, AuditLog, AuditLogFilter, AddonInfo, ProfileSummary };
+export {
+  ProfileListInfo,
+  ProfileInfo,
+  UsageStatistic,
+  AuditLog,
+  AuditLogCreateResponse,
+  AuditLogFilter,
+  AddonInfo,
+  ProfileSummary,
+};


### PR DESCRIPTION
AuditLogCreate will create the query for the logs.

AuditLogQuery will retrieve the logs for a given queryId. The status can be "Complete" or "Running" if still searching for the logs.