### PR TITLE
feat: sdk-13 migration icon widget mix structure

### DIFF
--- a/src/modules/Migration/icon.ts
+++ b/src/modules/Migration/icon.ts
@@ -112,14 +112,15 @@ export function convert(oldWidget: any): WidgetInfo {
 }
 
 export function isOldStructure(widget: any) {
-  const isOld = !!(
-    widget?.display?.vars_labels ||
-    widget?.display?.vars_format ||
-    widget?.display?.vars_formula ||
-    widget?.display?.numberformat ||
-    widget?.display?.hide_values ||
-    widget?.display?.hide_variables
-  );
+  const isOld =
+    !!(
+      widget?.display?.vars_labels ||
+      widget?.display?.vars_format ||
+      widget?.display?.vars_formula ||
+      widget?.display?.numberformat ||
+      widget?.display?.hide_values ||
+      widget?.display?.hide_variables
+    ) && !widget?.display?.variables;
 
   return isOld;
 }


### PR DESCRIPTION
The old migration was done by a flag on the Dashboard structure. If ```dashboard.background.isMigrate``` you should import always the new Widget’s component.

The new migration now checks each widget, if it is OLD converts on the new structure and import the new Widget’s component.

The following client complain that his Icon’s lost the custom color and conditions, this happens because his structure is a mix of old and new.

[Client community post.](https://community.tago.io/t/widget-losing-customization/1259)

[Dashboard template.
](https://admin.tago.io/template/61491764683cae001898701d)
![Captura de tela de 2021-12-06 12-15-00](https://user-images.githubusercontent.com/31892961/145203023-87ea6a55-d4a6-415e-a558-b43215c900db.png)
![Captura de tela de 2021-12-06 12-15-37](https://user-images.githubusercontent.com/31892961/145203028-189da05a-c8f6-4d60-af7a-56a1c2aafb0f.png)


