### PR TITLE
fix: cylinder color conditions sdk-14

### DIFF
--- a/src/modules/Migration/cylinder.ts
+++ b/src/modules/Migration/cylinder.ts
@@ -13,7 +13,7 @@ export function convert(oldWidget: any): WidgetInfo {
     decimalsString = oldDisplay?.numberformat?.split(".")?.[1] || "";
   }
   const decimals = decimalsString.length || -1;
-  
+
   const conditions =
     Array.isArray(oldDisplay?.conditions) && oldDisplay?.conditions.length > 0 ? oldDisplay?.conditions : [];
   conditions.reverse();
@@ -37,7 +37,7 @@ export function convert(oldWidget: any): WidgetInfo {
       theme: {
         color: {
           background: null,
-          fill:conditions,
+          fill: conditions,
           glass: null,
           header: null,
           text: null,

--- a/src/modules/Migration/cylinder.ts
+++ b/src/modules/Migration/cylinder.ts
@@ -13,6 +13,10 @@ export function convert(oldWidget: any): WidgetInfo {
     decimalsString = oldDisplay?.numberformat?.split(".")?.[1] || "";
   }
   const decimals = decimalsString.length || -1;
+  
+  const conditions =
+    Array.isArray(oldDisplay?.conditions) && oldDisplay?.conditions.length > 0 ? oldDisplay?.conditions : [];
+  conditions.reverse();
 
   const newStructure: any = {
     dashboard: oldWidget.dashboard,
@@ -33,8 +37,7 @@ export function convert(oldWidget: any): WidgetInfo {
       theme: {
         color: {
           background: null,
-          fill:
-            Array.isArray(oldDisplay?.conditions) && oldDisplay?.conditions.length > 0 ? oldDisplay?.conditions : null,
+          fill:conditions,
           glass: null,
           header: null,
           text: null,


### PR DESCRIPTION
In the Cylinder widget, the color condition priority was bottom-up, and the new is top-bottom.
![image](https://user-images.githubusercontent.com/31892961/146239850-8930e8eb-43ce-466d-8805-994b696d92f6.png)
The above conditions should be converted to this following order:
![image](https://user-images.githubusercontent.com/31892961/146239881-a93884ae-6ab8-47bc-b818-2c1ef2031087.png)
