### PR TITLE
fix: edit route and data type fixes [SDK-24]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tago-io/sdk",
-  "version": "10.6.0",
+  "version": "10.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tago-io/sdk",
-      "version": "10.6.0",
+      "version": "10.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "0.25.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tago-io/sdk",
-  "version": "10.6.0",
+  "version": "10.7.0",
   "description": "TagoIO SDK for JavaScript in the browser and Node.js",
   "author": "Tago LLC",
   "homepage": "https://tago.io",

--- a/src/common/common.types.ts
+++ b/src/common/common.types.ts
@@ -22,6 +22,13 @@ interface Metadata {
   [key: string]: any;
 }
 
+type LocationGeoJSON = {
+  type: "Point";
+  coordinates: number[];
+};
+
+type LocationLatLng = { lat: number; lng: number };
+
 /**
  * Type for the data returned from the API.
  */
@@ -65,10 +72,7 @@ interface Data {
   /**
    * Location for the data value.
    */
-  location?: {
-    type: "Point";
-    coordinates: number[];
-  };
+  location?: LocationGeoJSON;
   /**
    * Metadata for the data value.
    */
@@ -92,16 +96,7 @@ type DataCreate = Required<Pick<Data, "variable">> &
       /**
        * Location for the data value.
        */
-      location: {
-        /**
-         * Latitude for the data.
-         */
-        lat: number;
-        /**
-         * Latitude for the data.
-         */
-        lng: number;
-      };
+      location: LocationGeoJSON | LocationLatLng | null;
       /**
        * Timestamp for the data value.
        */

--- a/src/common/common.types.ts
+++ b/src/common/common.types.ts
@@ -22,6 +22,9 @@ interface Metadata {
   [key: string]: any;
 }
 
+/**
+ * Type for the data returned from the API.
+ */
 interface Data {
   /**
    * Data ID.
@@ -62,13 +65,16 @@ interface Data {
   /**
    * Location for the data value.
    */
-  location?: { lat: number; lng: number };
+  location?: {
+    type: "Point";
+    coordinates: number[];
+  };
   /**
    * Metadata for the data value.
    */
   metadata?: Metadata;
   /**
-   * Timestamp for the data value. Customizable when posting the data.
+   * Timestamp for the data value.
    */
   time: Date;
   /**
@@ -76,6 +82,38 @@ interface Data {
    */
   created_at?: Date;
 }
+
+/**
+ * Type for creating data and sending it to the API.
+ */
+type DataCreate = Required<Pick<Data, "variable">> &
+  Partial<
+    Omit<Data, "id" | "device" | "origin" | "location" | "time" | "created_at"> & {
+      /**
+       * Location for the data value.
+       */
+      location: {
+        /**
+         * Latitude for the data.
+         */
+        lat: number;
+        /**
+         * Latitude for the data.
+         */
+        lng: number;
+      };
+      /**
+       * Timestamp for the data value.
+       */
+      time: string | Date;
+    }
+  >;
+
+/**
+ * Type for editing data and sending it to the API.
+ */
+type DataEdit = Required<Pick<Data, "id">> &
+  Partial<Pick<DataCreate, "value" | "group" | "serie" | "unit" | "metadata" | "time" | "location">>;
 
 interface TagsObj {
   key: string;
@@ -186,6 +224,8 @@ interface ListTokenQuery
 
 export {
   Data,
+  DataCreate,
+  DataEdit,
   TagsObj,
   Query,
   Base64,

--- a/src/modules/Device/Device.ts
+++ b/src/modules/Device/Device.ts
@@ -1,19 +1,11 @@
 import chunk from "lodash.chunk";
 import Batch from "../../common/BatchRequest";
-import { Data, GenericID } from "../../common/common.types";
+import { Data, DataCreate, DataEdit, GenericID } from "../../common/common.types";
 import sleep from "../../common/sleep";
 import TagoIOModule from "../../common/TagoIOModule";
 import { ConfigurationParams } from "../Account/devices.types";
 import dateParser from "../Utils/dateParser";
-import {
-  DataQuery,
-  DataQueryStreaming,
-  DataToEdit,
-  DataToSend,
-  DeviceConstructorParams,
-  DeviceInfo,
-  OptionsStreaming,
-} from "./device.types";
+import { DataQuery, DataQueryStreaming, DeviceConstructorParams, DeviceInfo, OptionsStreaming } from "./device.types";
 
 class Device extends TagoIOModule<DeviceConstructorParams> {
   /**
@@ -51,7 +43,7 @@ class Device extends TagoIOModule<DeviceConstructorParams> {
    * });
    * ```
    */
-  public async sendData(data: DataToSend | DataToSend[]): Promise<string> {
+  public async sendData(data: DataCreate | DataCreate[]): Promise<string> {
     data = Array.isArray(data) ? data : [data];
 
     const result = await this.doRequest<string>({
@@ -104,22 +96,25 @@ class Device extends TagoIOModule<DeviceConstructorParams> {
   }
 
   /**
-   * Edit  data from device
-   * @param data An array or one object with data to be edited at TagoIO using device token
+   * Edit data in a Mutable-type device.
+   *
+   * @param data Array or object with the data to be edited, each object with the data's ID.
+   *
    * @example
-   * ```js
+   * ```ts
    * const myDevice = new Device({ token: "my_device_token" });
    *
    * const result = await myDevice.editData({
-   *   id: "619748fb5ef26e0012205378",
-   *   unit: "F",
-   *   value: 55,
-   *   time: "2015-11-03 13:44:33",
+   *   id: "id_of_the_data_item"
+   *   value: 123,
+   *   time: "2022-04-01 12:34:56",
    *   location: { lat: 42.2974279, lng: -85.628292 },
    * });
    * ```
+   *
+   * @returns Success message with the amount of data items updated.
    */
-  public async editData(data: DataToEdit | DataToEdit[]): Promise<string> {
+  public async editData(data: DataEdit | DataEdit[]): Promise<string> {
     data = Array.isArray(data) ? data : [data];
 
     const result = await this.doRequest<string>({
@@ -287,7 +282,7 @@ class Device extends TagoIOModule<DeviceConstructorParams> {
    *   });
    * ```
    */
-  public async sendDataStreaming(data: DataToSend[], options: Omit<OptionsStreaming, "neverStop">) {
+  public async sendDataStreaming(data: DataCreate[], options: Omit<OptionsStreaming, "neverStop">) {
     const poolingRecordQty = options?.poolingRecordQty || 1000;
     const poolingTime = options?.poolingTime || 1000; // 1 seg
 

--- a/src/modules/Device/device.types.ts
+++ b/src/modules/Device/device.types.ts
@@ -1,4 +1,4 @@
-import { Data, GenericID, GenericToken, TagsObj } from "../../common/common.types";
+import { Data, DataCreate, DataEdit, GenericID, GenericToken, TagsObj } from "../../common/common.types";
 import { Regions } from "../../regions";
 
 interface DeviceInfo {
@@ -34,8 +34,9 @@ interface DeviceConstructorParams {
   // options?: any;
 }
 
-type DataToSend = Omit<Data, "id" | "created_at" | "origin" | "device" | "time"> & { time?: Date | string };
-type DataToEdit = Omit<Data, "created_at" | "origin" | "device" | "time"> & { time?: Date | string };
+type DataToSend = DataCreate;
+type DataToEdit = DataEdit;
+
 type valuesTypes = string | number | boolean | void;
 
 interface DataQueryBase {


### PR DESCRIPTION
This PR fixes data types and creates a separate one for `DataEdit` (for the `PUT` request on `/data`) and `DataCreate` (for the `POST` request on `/data`). These types will also be used in new routes.