### PR TITLE
feat: add support for monthly and daily usage statistics [SDKJS-29]

### DIFF
--- a/src/modules/Account/Profile.ts
+++ b/src/modules/Account/Profile.ts
@@ -9,13 +9,14 @@ import {
 import TagoIOModule, { GenericModuleParams } from "../../common/TagoIOModule";
 import dateParser from "../Utils/dateParser";
 import { BillingAddOn } from "./billing.types";
-import {
+import type {
   AddonInfo,
   AuditLog,
   AuditLogFilter,
   ProfileInfo,
   ProfileListInfo,
   ProfileSummary,
+  StatisticsDate,
   UsageStatistic,
 } from "./profile.types";
 
@@ -130,15 +131,12 @@ class Profile extends TagoIOModule<GenericModuleParams> {
    * ```json
    * [
    *   { "time": "2022-01-01T00:00:00.000Z", "input": 5 },
-   *   { "time": "2022-01-01T00:00:00.000Z", "input": 5, "output": 10 },
-   *   { "time": "2022-01-01T00:00:00.000Z", "input": 10, "output": 15 },
+   *   { "time": "2022-01-02T00:00:00.000Z", "input": 5, "output": 10 },
+   *   { "time": "2022-01-03T00:00:00.000Z", "input": 10, "output": 15 },
    * ]
    * ```
    */
-  public async usageStatisticList(
-    profileID: GenericID,
-    dateObj?: { date?: string; timezone?: string }
-  ): Promise<UsageStatistic[]> {
+  public async usageStatisticList(profileID: GenericID, dateObj?: StatisticsDate): Promise<UsageStatistic[]> {
     let result = await this.doRequest<UsageStatistic[]>({
       path: `/profile/${profileID}/statistics`,
       method: "GET",

--- a/src/modules/Account/profile.types.ts
+++ b/src/modules/Account/profile.types.ts
@@ -132,7 +132,40 @@ interface AddonInfo {
   logo_url: string | null;
 }
 
-export {
+type DateFixed = {
+  /**
+   * Timestamp for fetching the hourly statistics in a day.
+   */
+  date?: string | Date | undefined;
+};
+
+type DateRange = {
+  /**
+   * Starting date for fetching statistics in a interval.
+   */
+  start_date: string | Date;
+  /**
+   * End date for fetching statistics in a interval.
+   */
+  end_date: string | Date;
+  /**
+   * Periodicity of the statistics to fetch.
+   *
+   * @default "hour"
+   */
+  periodicity: "hour" | "day" | "month";
+};
+
+type StatisticsDate = {
+  /**
+   * Timezone to be used in the statistics entries.
+   *
+   * @default "UTC"
+   */
+  timezone?: string;
+} & (DateFixed | DateRange);
+
+export type {
   ProfileListInfo,
   ProfileAddOns,
   ProfileInfo,
@@ -141,4 +174,5 @@ export {
   AuditLogFilter,
   AddonInfo,
   ProfileSummary,
+  StatisticsDate,
 };


### PR DESCRIPTION
This PR adds support for fetching daily and monthly usage statistics. The options now have a secondary type for fetching monthly/daily statistics.