### PR TITLE
fix: listStream wrong filter object

### DIFF
--- a/src/modules/Resources/Devices.ts
+++ b/src/modules/Resources/Devices.ts
@@ -77,7 +77,7 @@ class Devices extends TagoIOModule<GenericModuleParams> {
    * }
    * ```
    */
-  public async *listStreaming(queryObj?: DeviceQuery["filter"], options?: OptionsStreaming) {
+  public async *listStreaming(queryObj?: Omit<DeviceQuery, "page" | "amount">, options?: OptionsStreaming) {
     const poolingRecordQty = options?.poolingRecordQty || 1000;
     const poolingTime = options?.poolingTime || 500; // 500 ms
 


### PR DESCRIPTION
## What does PR do?

Fixes issue in the devices.listStream where the filter object was not being copy correctly to the list method

## Type of alteration

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
