### PR TITLE
Refactor router service to include additional conditions for device and user list identifiers

### DIFF
--- a/src/modules/Utils/router/service.ts
+++ b/src/modules/Utils/router/service.ts
@@ -63,7 +63,10 @@ class RouterService {
    * Information is available if Analysis is triggered by an input widget.
    */
   public whenDeviceListIdentifier(btn_id: string) {
-    this.addFunc((_scope: any, environment: any) => environment._widget_exec === btn_id);
+    this.addFunc(
+      (scope: any, environment: any) =>
+        environment._widget_exec === btn_id || !!scope.find((x: any) => x.device_list_button_id == btn_id)
+    );
     return this;
   }
 
@@ -72,7 +75,10 @@ class RouterService {
    * Information is available if Analysis is triggered by an input widget.
    */
   public whenUserListIdentifier(btn_id: string) {
-    this.addFunc((_scope: any, environment: any) => environment._widget_exec === btn_id);
+    this.addFunc(
+      (scope: any, environment: any) =>
+        environment._widget_exec === btn_id || !!scope.find((x: any) => x.user_list_button_id == btn_id)
+    );
     return this;
   }
 


### PR DESCRIPTION
## What does PR do?

This pull request refactors the router service to include additional conditions for device and user list identifiers. The `whenDeviceListIdentifier` and `whenUserListIdentifier` methods have been updated to check for the presence of the button ID in the scope array. This ensures that the router service functions correctly when triggered by an input widget.

## Type of alteration

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

