### PR TITLE
feat: deprecate buckets, fix DeviceInfo type, add data amount to Device resource

### DIFF
--- a/src/modules/Resources/Buckets.ts
+++ b/src/modules/Resources/Buckets.ts
@@ -2,7 +2,7 @@ import type { ExportOption, GenericID } from "../../common/common.types";
 import TagoIOModule, { GenericModuleParams } from "../../common/TagoIOModule";
 import Devices from "./Devices";
 import type { ExportBucket, ExportBucketOption } from "./buckets.types";
-import type { DeviceCreateInfo, DeviceEditInfo, DeviceQuery } from "./devices.types";
+import type { DeviceQuery } from "./devices.types";
 
 /**
  * @deprecated Use `Resources.devices` instead.
@@ -29,37 +29,6 @@ class Buckets extends TagoIOModule<GenericModuleParams> {
    */
   public async list<T extends DeviceQuery>(queryObj?: T) {
     return await this.devices.list(queryObj);
-  }
-
-  /**
-   * Create a new Device in the profile.
-   * @param deviceObj Object with the fields and values for a new Device.
-   *
-   * @deprecated Use the method from `Resources.devices` instead.
-   */
-  public async create(deviceObj: DeviceCreateInfo) {
-    return await this.devices.create(deviceObj);
-  }
-
-  /**
-   * Modify any property of the Device.
-   * @param deviceID Device ID
-   * @param deviceObj Object with the fields and values to modify.
-   *
-   * @deprecated Use the method from `Resources.devices` instead.
-   */
-  public async edit(deviceID: GenericID, deviceObj: DeviceEditInfo) {
-    return await this.devices.edit(deviceID, deviceObj);
-  }
-
-  /**
-   * Delete a device from the profile.
-   * @param deviceID Device ID
-   *
-   * @deprecated Use the method from `Resources.devices` instead.
-   */
-  public async delete(deviceID: GenericID) {
-    return await this.devices.delete(deviceID);
   }
 
   /**

--- a/src/modules/Resources/Buckets.ts
+++ b/src/modules/Resources/Buckets.ts
@@ -12,6 +12,10 @@ import {
   VariablesInfo,
 } from "./buckets.types";
 
+/**
+ * @deprecated Use `Resources.devices` instead.
+ */
+
 class Buckets extends TagoIOModule<GenericModuleParams> {
   /**
    * Retrieves a list with all buckets from account
@@ -26,6 +30,8 @@ class Buckets extends TagoIOModule<GenericModuleParams> {
    * }
    * ```
    * @param queryObj Search query params
+   *
+   * @deprecated Use the method from `Resources.devices` instead.
    */
   public async list(queryObj?: BucketQuery): Promise<BucketInfo[]> {
     let result = await this.doRequest<BucketInfo[]>({
@@ -48,6 +54,8 @@ class Buckets extends TagoIOModule<GenericModuleParams> {
   /**
    * Generates and retrieves a new bucket for the account
    * @param bucketObj Object with data to create new bucket
+   *
+   * @deprecated Use the method from `Resources.devices` instead.
    */
   public async create(bucketObj: BucketCreateInfo): Promise<{ bucket: string }> {
     const result = await this.doRequest<{ bucket: string }>({
@@ -63,6 +71,8 @@ class Buckets extends TagoIOModule<GenericModuleParams> {
    * Modifies any property of the bucket.
    * @param bucketID Bucket ID
    * @param bucketObj Bucket Object data to be replaced
+   *
+   * @deprecated Use the method from `Resources.devices` instead.
    */
   public async edit(bucketID: GenericID, bucketObj: Partial<BucketCreateInfo>): Promise<string> {
     const result = await this.doRequest<string>({
@@ -77,6 +87,8 @@ class Buckets extends TagoIOModule<GenericModuleParams> {
   /**
    * Deletes a bucket from the account
    * @param bucketID Bucket ID
+   *
+   * @deprecated Use the method from `Resources.devices` instead.
    */
   public async delete(bucketID: GenericID): Promise<string> {
     const result = await this.doRequest<string>({
@@ -90,6 +102,8 @@ class Buckets extends TagoIOModule<GenericModuleParams> {
   /**
    * Gets information about the bucket
    * @param bucketID Bucket ID
+   *
+   * @deprecated Use the method from `Resources.devices` instead.
    */
   public async info(bucketID: GenericID): Promise<BucketInfo> {
     let result = await this.doRequest<BucketInfo>({
@@ -104,6 +118,8 @@ class Buckets extends TagoIOModule<GenericModuleParams> {
   /**
    * Get Amount of data on the Bucket
    * @param bucketID Bucket ID
+   *
+   * @deprecated Use the method from `Resources.devices` instead.
    */
   public async amount(bucketID: GenericID): Promise<number> {
     const result = await this.doRequest<number>({
@@ -127,6 +143,8 @@ class Buckets extends TagoIOModule<GenericModuleParams> {
    * ```
    * @param bucketID Bucket ID
    * @param optionsObj Request options
+   *
+   * @deprecated
    */
   public async listVariables(bucketID: GenericID, optionsObj?: ListVariablesOptions): Promise<VariablesInfo[]> {
     const result = await this.doRequest<VariablesInfo[]>({
@@ -146,6 +164,8 @@ class Buckets extends TagoIOModule<GenericModuleParams> {
    * Delete a bucket variable
    * @param bucketID Bucket ID
    * @param deleteParams Variable Details
+   *
+   * @deprecated
    */
   public async deleteVariable(
     bucketID: GenericID,
@@ -163,6 +183,8 @@ class Buckets extends TagoIOModule<GenericModuleParams> {
   /**
    * Get all device associated with bucket
    * @param bucketID Bucket ID
+   *
+   * @deprecated
    */
   public async getDevicesAssociated(bucketID: GenericID): Promise<BucketDeviceInfo[]> {
     const result = await this.doRequest<BucketDeviceInfo[]>({
@@ -179,6 +201,8 @@ class Buckets extends TagoIOModule<GenericModuleParams> {
    * @param buckets Array of JSON with get details
    * @param output Type of output
    * @param optionsObj Options of request
+   *
+   * @deprecated
    */
   public async exportData(
     buckets: ExportBucket,

--- a/src/modules/Resources/Devices.ts
+++ b/src/modules/Resources/Devices.ts
@@ -59,9 +59,7 @@ class Devices extends TagoIOModule<GenericModuleParams> {
       },
     });
 
-    result = result.map((data) =>
-      dateParser(data, ["last_input", "last_output", "updated_at", "created_at", "inspected_at"])
-    );
+    result = result.map((data) => dateParser(data, ["last_input", "updated_at", "created_at"]));
 
     return result;
   }
@@ -160,14 +158,7 @@ class Devices extends TagoIOModule<GenericModuleParams> {
       method: "GET",
     });
 
-    result = dateParser(result, [
-      "last_input",
-      "last_output",
-      "updated_at",
-      "created_at",
-      "inspected_at",
-      "last_retention",
-    ]);
+    result = dateParser(result, ["last_input", "updated_at", "created_at"]);
 
     return result;
   }
@@ -290,6 +281,20 @@ class Devices extends TagoIOModule<GenericModuleParams> {
     const result = await this.doRequest<string>({
       path: `/device/token/${token}`,
       method: "DELETE",
+    });
+
+    return result;
+  }
+
+  /**
+   * Get amount of data stored in the Device.
+   *
+   * @param deviceID Device ID
+   */
+  public async amount(deviceID: GenericID): Promise<number> {
+    const result = await this.doRequest<number>({
+      path: `/device/${deviceID}/data_amount`,
+      method: "GET",
     });
 
     return result;

--- a/src/modules/Resources/TagoCores.ts
+++ b/src/modules/Resources/TagoCores.ts
@@ -215,7 +215,7 @@ class TagoCores extends TagoIOModule<GenericModuleParams> {
       params: { tcore: tagoCoreID },
     });
 
-    result = dateParser(result, ["last_input", "last_output", "updated_at", "created_at", "inspected_at"]);
+    result = dateParser(result, ["last_input", "updated_at", "created_at"]);
 
     return result;
   }
@@ -232,7 +232,7 @@ class TagoCores extends TagoIOModule<GenericModuleParams> {
       params: { tcore_cluster: clusterID },
     });
 
-    result = dateParser(result, ["last_input", "last_output", "updated_at", "created_at", "inspected_at"]);
+    result = dateParser(result, ["last_input", "updated_at", "created_at"]);
 
     return result;
   }
@@ -266,9 +266,7 @@ class TagoCores extends TagoIOModule<GenericModuleParams> {
       },
     });
 
-    result = result.map((data) =>
-      dateParser(data, ["last_input", "last_output", "updated_at", "created_at", "inspected_at"])
-    );
+    result = result.map((data) => dateParser(data, ["last_input", "updated_at", "created_at"]));
 
     return result;
   }
@@ -302,9 +300,7 @@ class TagoCores extends TagoIOModule<GenericModuleParams> {
       },
     });
 
-    result = result.map((data) =>
-      dateParser(data, ["last_input", "last_output", "updated_at", "created_at", "inspected_at"])
-    );
+    result = result.map((data) => dateParser(data, ["last_input", "updated_at", "created_at"]));
 
     return result;
   }


### PR DESCRIPTION
## What does PR do?

PR based on #111 (branch: `sse_others`)

Fixes:

- Fixing missing properties in `DeviceInfo` and type union over `type`
- Marking methods in `Resources.buckets` as deprecated
- Adding `amount` to `Resources.devices` to get the data amount stored in the Device

## Type of alteration

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
