### PR TITLE
Add MQTT relay publishing method

### DIFF
--- a/src/modules/Network/Network.ts
+++ b/src/modules/Network/Network.ts
@@ -130,12 +130,11 @@ class Network extends TagoIOModule<ConnectorModuleParams> {
       method: "POST",
       body: paramID
         ? {
-          id: paramID,
-          ...configObj,
-        }
+            id: paramID,
+            ...configObj,
+          }
         : configObj,
     });
-
     return result;
   }
 }

--- a/src/modules/Network/Network.ts
+++ b/src/modules/Network/Network.ts
@@ -129,11 +129,11 @@ class Network extends TagoIOModule<ConnectorModuleParams> {
       path: `/integration/network/${deviceID}/params`,
       method: "POST",
       body: paramID
-      ? {
-        id: paramID,
-        ...configObj,
-      }
-    : configObj,
+        ? {
+          id: paramID,
+          ...configObj,
+        }
+        : configObj,
     });
 
     return result;

--- a/src/modules/Network/Network.ts
+++ b/src/modules/Network/Network.ts
@@ -133,7 +133,7 @@ class Network extends TagoIOModule<ConnectorModuleParams> {
         id: paramID,
         ...configObj,
       }
-        : configObj,
+    : configObj,
     });
 
     return result;

--- a/src/modules/Network/Network.ts
+++ b/src/modules/Network/Network.ts
@@ -1,8 +1,8 @@
-import TagoIOModule, { ConnectorModuleParams } from "../../common/TagoIOModule";
-import { NetworkDeviceListQuery, INetworkInfo, NetworkDeviceListQueryInfo } from "./network.types";
 import { GenericID, GenericToken } from "../../common/common.types";
-import dateParser from "../Utils/dateParser";
+import TagoIOModule, { ConnectorModuleParams } from "../../common/TagoIOModule";
 import { ConfigurationParams } from "../Resources/devices.types";
+import dateParser from "../Utils/dateParser";
+import { INetworkInfo, NetworkDeviceListQuery, NetworkDeviceListQueryInfo } from "./network.types";
 
 class Network extends TagoIOModule<ConnectorModuleParams> {
   /**
@@ -35,6 +35,43 @@ class Network extends TagoIOModule<ConnectorModuleParams> {
       method: "GET",
       params: {
         details: this.params.details,
+      },
+    });
+
+    return result;
+  }
+
+  /**
+   * Publish a message to the MQTT relay
+   * @param options Options for publishing the message
+   * @param options.topic The topic to publish to
+   * @param options.message The message to publish (optional)
+   * @param options.qos Quality of Service level (optional)
+   * @param options.bucket The bucket to publish to (optional)
+   * @param options.retain Whether to retain the message (optional)
+   * @param options.device The device to publish to (optional)
+   * @returns A promise that resolves when the message is published
+   */
+  public async publishToRelay(options: {
+    topic: string;
+    message?: string;
+    qos?: number;
+    retain?: boolean;
+    device: string;
+  }): Promise<string> {
+    if (!options.device) {
+      throw new Error("Either bucket or device must be provided");
+    }
+
+    const result = await this.doRequest<string>({
+      path: "/integration/network/publish",
+      method: "POST",
+      body: {
+        topic: options.topic,
+        message: options.message,
+        qos: options.qos,
+        retain: options.retain,
+        device: options.device,
       },
     });
 
@@ -92,10 +129,10 @@ class Network extends TagoIOModule<ConnectorModuleParams> {
       path: `/integration/network/${deviceID}/params`,
       method: "POST",
       body: paramID
-        ? {
-            id: paramID,
-            ...configObj,
-          }
+      ? {
+        id: paramID,
+        ...configObj,
+      }
         : configObj,
     });
 


### PR DESCRIPTION
## What does PR do?

This pull request adds a new method to the Network class called `publishToRelay()`. This method allows users to publish a message to the MQTT relay. The method takes in various options such as the topic, message, quality of service level, bucket, retain flag, and device. It then sends a request to the server to publish the message. This new method enhances the functionality of the Network class and provides users with more flexibility when working with MQTT relay.

## Type of alteration

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update


