### PR TITLE
feat: support multichannel SSE connections

### DIFF
--- a/src/modules/Analysis/Analysis.ts
+++ b/src/modules/Analysis/Analysis.ts
@@ -123,11 +123,10 @@ class Analysis extends TagoIOModule<AnalysisConstructorParams> {
       console.info("¬ Warning :: Analysis is not set to run on external");
     }
 
-    const sse = await openSSEListening({
-      token: this.params.token,
-      region: this.params.region,
-      channel: "analysis_trigger",
-    });
+    const sse = await openSSEListening(
+      { channel: "analysis_trigger" },
+      { token: this.params.token, region: this.params.region }
+    );
 
     const tokenEnd = this.params.token.slice(-5);
 


### PR DESCRIPTION
## What does PR do?

Support multi-channel connections on SSE, which is in a newer version of the SSE service.

This PR **changes the function signature** for `openSSEListening` for a few reasons:

- Support a single channel or multiple channels as the first parameter (URL is built differently for multi-channel)
- Move `token`/`region` to second parameter since it's decoupled from the channels

Type definitions show these changes in the editor properly in case of updating from a previous version.

### Example

```ts
const single = await openSSEListening(
  { channel: "device_inspector", resource_id: "1234" },
  { token: "my-token", region: "usa-1" },
);

const multi = await openSSEListening(
  [
    { channel: "device_inspector", resource_id: "1234" },
    { channel: "device_inspector", resource_id: "5678" },
    { channel: "ui" },
  ],
  { token: "my-token", region: "usa-1" },
);
```

For comparison, here's an example using the **old function signature**:

```ts
const single = await openSSEListening({
  channel: "device_inspector",
  resource_id: "1234",
  token: "my-token",
  region: "usa-1",
});
```

## Type of alteration

- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [ ] Documentation update
