### PR TITLE
fix: move details parameter to DataQueryBase

### DIFF
--- a/src/modules/Device/device.types.ts
+++ b/src/modules/Device/device.types.ts
@@ -86,6 +86,10 @@ interface DataQueryBase {
    * Date.now()
    */
   end_date?: Date | string;
+  /**
+   * Add internal details in each record
+   */
+  details?: boolean;
 }
 
 type DataQueryDefault = DataQueryBase & {
@@ -94,10 +98,6 @@ type DataQueryDefault = DataQueryBase & {
    * Qty of records to retrieve
    */
   qty?: number;
-  /**
-   * Add internal details in each record
-   */
-  details?: boolean;
   /**
    * Change ordination of query
    * @default "descending"


### PR DESCRIPTION
## What does PR do?

This PR moves the `details` parameter to `DataQueryBase` so it can be used in different data queries, such as `last_insert` and so on.

## Type of alteration

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
