### PR TITLE
feat: add support for Europe region [SDKJS-50]

### DIFF
--- a/src/modules/Analysis/analysis.types.ts
+++ b/src/modules/Analysis/analysis.types.ts
@@ -1,10 +1,10 @@
-import { Regions } from "../../regions";
+import { Regions, RegionsObj } from "../../regions";
 
 type analysisFunction = (context: any, data: any) => any;
 
 interface AnalysisConstructorParams {
   token?: string;
-  region?: Regions;
+  region?: Regions | RegionsObj;
   // options?: any;
   /**
    * Auto Start analysis after instance the class

--- a/src/modules/Device/device.types.ts
+++ b/src/modules/Device/device.types.ts
@@ -1,5 +1,5 @@
 import { Data, DataCreate, DataEdit, GenericID, GenericToken, TagsObj } from "../../common/common.types";
-import { Regions } from "../../regions";
+import { Regions, RegionsObj } from "../../regions";
 
 interface DeviceItem {
   id: GenericID;
@@ -31,7 +31,7 @@ interface DeviceItem {
  */
 interface DeviceConstructorParams {
   token: GenericToken;
-  region?: Regions;
+  region?: Regions | RegionsObj;
   // options?: any;
 }
 

--- a/src/modules/Dictionary/Dictionary.ts
+++ b/src/modules/Dictionary/Dictionary.ts
@@ -51,11 +51,14 @@ class Dictionary extends TagoIOModule<IDictionaryModuleParams> {
         });
         return response;
       } else {
-        const response = await TagoIOModule.doRequestAnonymous<LanguageData>({
-          path: `/dictionary/${this.runURL}/${dictionary}/${language}`,
-          method: "GET",
-          cacheTTL: 3600000,
-        });
+        const response = await TagoIOModule.doRequestAnonymous<LanguageData>(
+          {
+            path: `/dictionary/${this.runURL}/${dictionary}/${language}`,
+            method: "GET",
+            cacheTTL: 3600000,
+          },
+          this.params.region
+        );
         return response;
       }
     } catch (e) {

--- a/src/modules/Resources/Account.ts
+++ b/src/modules/Resources/Account.ts
@@ -1,6 +1,6 @@
 import { GenericToken } from "../../common/common.types";
 import TagoIOModule, { doRequestParams, GenericModuleParams } from "../../common/TagoIOModule";
-import { Regions } from "../../regions";
+import { Regions, RegionsObj } from "../../regions";
 import dateParser from "../Utils/dateParser";
 import {
   AccountCreateInfo,
@@ -59,7 +59,10 @@ class Account extends TagoIOModule<GenericModuleParams> {
    * @param tokenParams Token data
    * @param region TagoIO Region Server [default usa-1]
    */
-  public static async tokenCreate(tokenParams: TokenCreateInfo, region?: Regions): Promise<{ token: GenericToken }> {
+  public static async tokenCreate(
+    tokenParams: TokenCreateInfo,
+    region?: Regions | RegionsObj
+  ): Promise<{ token: GenericToken }> {
     const params: doRequestParams = {
       path: "/account/profile/token",
       method: "POST",
@@ -76,7 +79,7 @@ class Account extends TagoIOModule<GenericModuleParams> {
    * @param credentials Credentials
    * @param region TagoIO Region Server [default usa-1]
    */
-  public static async login(credentials: LoginCredentials, region?: Regions): Promise<LoginResponse> {
+  public static async login(credentials: LoginCredentials, region?: Regions | RegionsObj): Promise<LoginResponse> {
     const params: doRequestParams = {
       path: "/account/login",
       method: "POST",
@@ -93,7 +96,7 @@ class Account extends TagoIOModule<GenericModuleParams> {
    * @param email E-mail to recovery
    * @param region TagoIO Region Server [default usa-1]
    */
-  public static async passwordRecover(email: string, region?: Regions): Promise<string> {
+  public static async passwordRecover(email: string, region?: Regions | RegionsObj): Promise<string> {
     const params: doRequestParams = {
       path: `/account/passwordreset/${email}`,
       method: "GET",
@@ -125,7 +128,7 @@ class Account extends TagoIOModule<GenericModuleParams> {
    * @param createParams New account details
    * @param region TagoIO Region Server [default usa-1]
    */
-  public static async create(createParams: AccountCreateInfo, region?: Regions): Promise<string> {
+  public static async create(createParams: AccountCreateInfo, region?: Regions | RegionsObj): Promise<string> {
     const params: doRequestParams = {
       path: `/account`,
       method: "POST",
@@ -142,7 +145,7 @@ class Account extends TagoIOModule<GenericModuleParams> {
    * @param email E-mail address
    * @param region TagoIO Region Server [default usa-1]
    */
-  public static async resendConfirmation(email: string, region?: Regions): Promise<string> {
+  public static async resendConfirmation(email: string, region?: Regions | RegionsObj): Promise<string> {
     const params: doRequestParams = {
       path: `/account/resend_confirmation/${email}`,
       method: "GET",
@@ -158,7 +161,7 @@ class Account extends TagoIOModule<GenericModuleParams> {
    * @param token Confirmation token
    * @param region TagoIO Region Server [default usa-1]
    */
-  public static async confirmAccount(token: GenericToken, region?: Regions): Promise<string> {
+  public static async confirmAccount(token: GenericToken, region?: Regions | RegionsObj): Promise<string> {
     const params: doRequestParams = {
       path: `/account/confirm/${token}`,
       method: "GET",
@@ -177,7 +180,7 @@ class Account extends TagoIOModule<GenericModuleParams> {
   public static async requestLoginPINCode(
     credentials: { email: string; password: string },
     typeOTP: OTPType,
-    region?: Regions
+    region?: Regions | RegionsObj
   ): Promise<string> {
     const params: doRequestParams = {
       path: `/account/login/otp`,
@@ -243,11 +246,14 @@ class Account extends TagoIOModule<GenericModuleParams> {
    *
    * @returns Success message.
    */
-  public static async acceptTeamInvitation(token: string): Promise<string> {
-    const result = await TagoIOModule.doRequestAnonymous<string>({
-      path: `/profile/team/accept/${token}`,
-      method: "GET",
-    });
+  public static async acceptTeamInvitation(token: string, region?: Regions | RegionsObj): Promise<string> {
+    const result = await TagoIOModule.doRequestAnonymous<string>(
+      {
+        path: `/profile/team/accept/${token}`,
+        method: "GET",
+      },
+      region
+    );
 
     return result;
   }
@@ -257,11 +263,14 @@ class Account extends TagoIOModule<GenericModuleParams> {
    *
    * @returns Success message.
    */
-  public static async declineTeamInvitation(token: string): Promise<string> {
-    const result = await TagoIOModule.doRequestAnonymous<string>({
-      path: `/profile/team/decline/${token}`,
-      method: "GET",
-    });
+  public static async declineTeamInvitation(token: string, region?: Regions | RegionsObj): Promise<string> {
+    const result = await TagoIOModule.doRequestAnonymous<string>(
+      {
+        path: `/profile/team/decline/${token}`,
+        method: "GET",
+      },
+      region
+    );
 
     return result;
   }

--- a/src/modules/RunUser/RunUser.ts
+++ b/src/modules/RunUser/RunUser.ts
@@ -111,7 +111,11 @@ class RunUser extends TagoIOModule<GenericModuleParams> {
    * @param token TagoIO Run user token
    * @param region TagoIO Region Server [default usa-1]
    */
-  public static async confirmUser(tagoIORunURL: string, token: GenericToken, region?: Regions): Promise<string> {
+  public static async confirmUser(
+    tagoIORunURL: string,
+    token: GenericToken,
+    region?: Regions | RegionsObj
+  ): Promise<string> {
     const params: doRequestParams = {
       path: `/run/${tagoIORunURL}/confirm/${token}`,
       method: "GET",

--- a/src/modules/Utils/getAPIVersion.ts
+++ b/src/modules/Utils/getAPIVersion.ts
@@ -1,8 +1,8 @@
 import TagoIOModule, { GenericModuleParams, doRequestParams } from "../../common/TagoIOModule";
-import { Regions } from "../../regions";
+import { Regions, RegionsObj } from "../../regions";
 
 class GetAPIVersion extends TagoIOModule<GenericModuleParams> {
-  public static async getVersion(region?: Regions): Promise<string> {
+  public static async getVersion(region?: Regions | RegionsObj): Promise<string> {
     const params: doRequestParams = {
       path: "/status",
       method: "GET",

--- a/src/regions.ts
+++ b/src/regions.ts
@@ -5,19 +5,25 @@
 
 interface RegionsObj {
   api: string;
-  realtime: string;
+  realtime?: string;
   sse: string;
 }
+
+type Regions = "us-e1" | "eu-w1" | "env";
 
 /**
  * Object of Regions Definition
  * @internal
  */
 const regionsDefinition = {
-  "usa-1": {
+  "us-e1": {
     api: "https://api.tago.io",
     realtime: "https://realtime.tago.io",
     sse: "https://sse.tago.io/events",
+  },
+  "eu-w1": {
+    api: "https://api.eu-w1.tago.io",
+    sse: "https://sse.eu-w1.tago.io/events",
   },
   env: undefined as void, // ? process object should be on trycatch.
 };
@@ -28,6 +34,11 @@ const regionsDefinition = {
  * @param region Region
  */
 function getConnectionURI(region?: Regions | RegionsObj): RegionsObj {
+  // @ts-expect-error Fallback
+  if (region === "usa-1") {
+    region = "us-e1";
+  }
+
   const value =
     typeof region === "string" ? regionsDefinition[region] : typeof region === "object" ? region : undefined;
 
@@ -55,11 +66,10 @@ function getConnectionURI(region?: Regions | RegionsObj): RegionsObj {
     //   noRegionWarning = true;
     // }
 
-    return regionsDefinition["usa-1"];
+    return regionsDefinition["us-e1"];
   }
 }
 
-type Regions = "usa-1" | "env";
-
 export default getConnectionURI;
-export { Regions, RegionsObj };
+export type { Regions, RegionsObj };
+export { regionsDefinition };


### PR DESCRIPTION
## What does PR do?

- Add support for the new Europe region (`eu-w1`)
- Rename `usa-1` to `us-e1`, with fallback when passing `usa-1`
- Add the `region` parameter to methods that didn't have support for it

## Type of alteration

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
