### PR TITLE
fix: save runtime region from Analysis.use to be inherited by other modules [SDKJS-51]

### DIFF
--- a/src/modules/Analysis/Analysis.ts
+++ b/src/modules/Analysis/Analysis.ts
@@ -3,6 +3,7 @@ import ConsoleService from "../Services/Console";
 import { openSSEListening } from "../../infrastructure/apiSSE";
 import { AnalysisConstructorParams, analysisFunction, AnalysisEnvironment } from "./analysis.types";
 import { JSONParseSafe } from "../../common/JSONParseSafe";
+import getRegionObj, { setRuntimeRegion } from "../../regions";
 
 /**
  * This class is used to instance an analysis
@@ -153,8 +154,13 @@ class Analysis extends TagoIOModule<AnalysisConstructorParams> {
   }
 
   public static use(analysis: analysisFunction, params?: AnalysisConstructorParams) {
-    if (!process.env.T_ANALYSIS_TOKEN) {
+    if (!process.env.T_ANALYSIS_TOKEN && params?.token) {
       process.env.T_ANALYSIS_TOKEN = params.token;
+    }
+
+    const runtimeRegion = params?.region ? getRegionObj(params.region) : null;
+    if (runtimeRegion) {
+      setRuntimeRegion(runtimeRegion);
     }
 
     return new Analysis(analysis, params);

--- a/src/regions.ts
+++ b/src/regions.ts
@@ -28,6 +28,8 @@ const regionsDefinition = {
   env: undefined as void, // ? process object should be on trycatch.
 };
 
+let runtimeRegion: RegionsObj | undefined;
+
 /**
  * Get connection URI for Realtime and API
  * @internal
@@ -44,6 +46,10 @@ function getConnectionURI(region?: Regions | RegionsObj): RegionsObj {
 
   if (value) {
     return value;
+  }
+
+  if (runtimeRegion) {
+    return runtimeRegion;
   }
 
   if (region !== undefined && !region !== null && region !== "env") {
@@ -70,6 +76,28 @@ function getConnectionURI(region?: Regions | RegionsObj): RegionsObj {
   }
 }
 
+/**
+ * Set region in-memory to be inherited by other modules when set in the Analysis runtime
+ * with `Analysis.use()`.
+ *
+ * @example
+ *
+ * ```ts
+ * async function myAnalysis(context, scope) {
+ *   // this uses the region defined through `use`
+ *   const resources = new Resources({ token });
+ *
+ *   // it's still possible to override if needed
+ *   const europeResources = new Resources({ token, region: "eu-w1" });
+ * }
+ *
+ * Analysis.use(myAnalysis, { region: "us-e1" });
+ * ```
+ */
+function setRuntimeRegion(region: RegionsObj) {
+  runtimeRegion = region;
+}
+
 export default getConnectionURI;
 export type { Regions, RegionsObj };
-export { regionsDefinition };
+export { regionsDefinition, setRuntimeRegion };


### PR DESCRIPTION
## What does PR do?

- Set the region passed in `params` to be used as default in the runtime (e.g. `Analysis.use(myAnalysis, { region: "eu-w1" }`)

## Type of alteration

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
