### PR TITLE
fix: handling of Files URLs for TagoDeploy [SDKJS-54]

### DIFF
--- a/src/modules/Resources/Files.test.ts
+++ b/src/modules/Resources/Files.test.ts
@@ -1,0 +1,120 @@
+import Files from "./Files";
+
+describe("Files", () => {
+  let filesInstance: Files;
+  let doRequestSpy: jest.SpyInstance;
+
+  const requestBase = {
+    method: "GET",
+    params: { noRedirect: true },
+  };
+
+  const successResponse = {
+    status: true,
+    result: "signed-url",
+  };
+
+  beforeEach(() => {
+    filesInstance = new Files({ token: "test-token" });
+
+    doRequestSpy = jest.spyOn(filesInstance as any, "doRequest");
+    doRequestSpy.mockResolvedValue(successResponse);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("getFileURLSigned", () => {
+    it("calls getPathFromUrl and doRequest for a valid TagoIO URL", async () => {
+      const baseURL = "https://api.tago.io";
+
+      const rootPath = "/file/my-test-file.txt";
+      const rootResult = await filesInstance.getFileURLSigned(`${baseURL}${rootPath}`);
+
+      expect(doRequestSpy).toHaveBeenCalledTimes(1);
+      expect(doRequestSpy).toHaveBeenCalledWith({ ...requestBase, path: rootPath });
+      expect(rootResult).toEqual(successResponse);
+      doRequestSpy.mockClear();
+
+      const nestedPath = "/file/folder/sub1/sub2/my-test-file.txt";
+      const nestedResult = await filesInstance.getFileURLSigned(`${baseURL}${nestedPath}`);
+
+      expect(doRequestSpy).toHaveBeenCalledTimes(1);
+      expect(doRequestSpy).toHaveBeenCalledWith({ ...requestBase, path: nestedPath });
+      expect(nestedResult).toEqual(successResponse);
+    });
+
+    it("calls getPathFromUrl and doRequest for a valid default TagoDeploy URL", async () => {
+      const baseURL = "https://api.PROJECT_ID.tagoio.net";
+
+      const rootPath = "/file/my-test-file.txt";
+      const rootResult = await filesInstance.getFileURLSigned(`${baseURL}${rootPath}`);
+
+      expect(doRequestSpy).toHaveBeenCalledTimes(1);
+      expect(doRequestSpy).toHaveBeenCalledWith({ ...requestBase, path: rootPath });
+      expect(rootResult).toEqual(successResponse);
+      doRequestSpy.mockClear();
+
+      const nestedPath = "/file/folder/sub1/sub2/my-test-file.txt";
+      const nestedResult = await filesInstance.getFileURLSigned(`${baseURL}${nestedPath}`);
+
+      expect(doRequestSpy).toHaveBeenCalledTimes(1);
+      expect(doRequestSpy).toHaveBeenCalledWith({ ...requestBase, path: nestedPath });
+      expect(nestedResult).toEqual(successResponse);
+    });
+
+    it("calls getPathFromUrl and doRequest for a valid custom TagoDeploy URL", async () => {
+      const baseURL = "https://api.mytagodeploy.project.com";
+
+      const rootPath = "/file/my-test-file.txt";
+      const rootResult = await filesInstance.getFileURLSigned(`${baseURL}${rootPath}`);
+
+      expect(doRequestSpy).toHaveBeenCalledTimes(1);
+      expect(doRequestSpy).toHaveBeenCalledWith({ ...requestBase, path: rootPath });
+      expect(rootResult).toEqual(successResponse);
+      doRequestSpy.mockClear();
+
+      const nestedPath = "/file/folder/sub1/sub2/my-test-file.txt";
+      const nestedResult = await filesInstance.getFileURLSigned(`${baseURL}${nestedPath}`);
+
+      expect(doRequestSpy).toHaveBeenCalledTimes(1);
+      expect(doRequestSpy).toHaveBeenCalledWith({ ...requestBase, path: nestedPath });
+      expect(nestedResult).toEqual(successResponse);
+    });
+
+    it("returns error for invalid protocols", async () => {
+      const filePath = "/file/my-test-file.txt";
+
+      expect(filesInstance.getFileURLSigned(`mailto:test@tago.io${filePath}`)).rejects.toMatch(/invalid protocol/);
+      expect(filesInstance.getFileURLSigned(`mailto:test@tago.io${filePath}`)).rejects.toMatch(/invalid protocol/);
+      expect(filesInstance.getFileURLSigned(`ftp://ftp.tago.io${filePath}`)).rejects.toMatch(/invalid protocol/);
+
+      expect(doRequestSpy).not.toHaveBeenCalled();
+    });
+
+    it("returns error for URLs without the proper files path", async () => {
+      const baseURL = "https://api.tago.io";
+
+      expect(filesInstance.getFileURLSigned(`${baseURL}`)).rejects.toMatch(/invalid path/);
+      expect(filesInstance.getFileURLSigned(`${baseURL}/`)).rejects.toMatch(/invalid path/);
+      expect(filesInstance.getFileURLSigned(`${baseURL}/file`)).rejects.toMatch(/invalid path/);
+      expect(filesInstance.getFileURLSigned(`${baseURL}/file.txt`)).rejects.toMatch(/invalid path/);
+      expect(filesInstance.getFileURLSigned(`${baseURL}/FILE/something.txt`)).rejects.toMatch(/invalid path/);
+      expect(filesInstance.getFileURLSigned(`${baseURL}/test/file/something.txt`)).rejects.toMatch(/invalid path/);
+      expect(filesInstance.getFileURLSigned(`${baseURL}/files/something.txt`)).rejects.toMatch(/invalid path/);
+
+      expect(filesInstance.getFileURLSigned("https://file")).rejects.toMatch(/invalid path/);
+      expect(filesInstance.getFileURLSigned("https://file/test.txt")).rejects.toMatch(/invalid path/);
+
+      expect(doRequestSpy).not.toHaveBeenCalled();
+    });
+
+    it("returns error for malformed URLs", async () => {
+      expect(filesInstance.getFileURLSigned("https:/")).rejects.toMatch(/not a valid URL/);
+      expect(filesInstance.getFileURLSigned("https://")).rejects.toMatch(/not a valid URL/);
+
+      expect(doRequestSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/modules/Resources/Files.ts
+++ b/src/modules/Resources/Files.ts
@@ -201,14 +201,24 @@ class Files extends TagoIOModule<GenericModuleParams> {
     return result;
   }
 
-  private async getPathFromUrl(url: string): Promise<string> {
-    const tagoURL = url.indexOf(".tago.io/file/");
+  private async getPathFromUrl(rawURL: string): Promise<string> {
+    const urlString = rawURL.trim();
 
-    if (tagoURL === -1) {
-      return Promise.reject(`${url} is not a TagoIO files url`);
+    try {
+      const url = new URL(urlString);
+
+      if (url.protocol !== "https:" && url.protocol !== "http:") {
+        return Promise.reject(`${urlString} uses an invalid protocol for TagoIO Files`);
+      }
+
+      if (!url.pathname.startsWith("/file/")) {
+        return Promise.reject(`${urlString} uses an invalid path for TagoIO Files`);
+      }
+
+      return url.pathname;
+    } catch {
+      return Promise.reject(`${urlString} is not a valid URL for TagoIO Files`);
     }
-
-    return url.slice(tagoURL + 8, url.length);
   }
 
   /**


### PR DESCRIPTION
## What does PR do?

Fix validation for URL restricting the TagoIO Files system only to `.tago.io`, which makes Files not 100% usable for TagoDeploy.

## Type of alteration

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
