### PR TITLE
fix: regression in Dashboard API to delete data [SDKJS-55]

### DIFF
--- a/src/common/common.types.ts
+++ b/src/common/common.types.ts
@@ -113,6 +113,8 @@ interface Query<T, U> {
 /** ID used on TagoIO, string with 24 character */
 type GenericID = string;
 
+type GenericIDPair = `${string}:${string}`;
+
 /** Token used on TagoIO, string with 36 characters */
 type GenericToken = string;
 
@@ -185,6 +187,7 @@ export {
   Query,
   Base64,
   GenericID,
+  GenericIDPair,
   GenericToken,
   PermissionOption,
   ExpireTimeOption,

--- a/src/modules/Resources/Dashboard.Widgets.ts
+++ b/src/modules/Resources/Dashboard.Widgets.ts
@@ -1,4 +1,4 @@
-import { Data, GenericID, GenericToken } from "../../common/common.types";
+import { GenericID, GenericIDPair, GenericToken } from "../../common/common.types";
 import TagoIOModule, { GenericModuleParams } from "../../common/TagoIOModule";
 import {
   EditDataModel,
@@ -206,28 +206,28 @@ class Widgets extends TagoIOModule<GenericModuleParams> {
   }
 
   /**
-   * @description Removes specific data points from the widget by their IDs.
+   * @description Removes multiple data items from the widget by pairs of data ID and resource ID.
    *
    * @example
    * ```typescript
    * const resources = new Resources({ token: "YOUR-PROFILE-TOKEN" });
-   * const result = await resources.dashboards.widgets.deleteData(
-   *   "dashboard-id-123", "widget-id-456", "data-id-789", "device-id-123"
+   * const result = await resources.dashboards.widgets.deleteMultipleData(
+   *   "dashboard-id",
+   *   "widget-id",
+   *   [
+   *     "data_1-id:device_A-id",
+   *     "data_2-id:device_A-id",
+   *     "data_3-id:device_B-id",
+   *   ]
    * );
-   * console.log(result); // Widget Data Removed
    * ```
    */
-  public async deleteData(
-    dashboardID: GenericID,
-    widgetID: GenericID,
-    variableID: GenericID,
-    deviceID: GenericID
-  ): Promise<string> {
+  public async deleteData(dashboardID: GenericID, widgetID: GenericID, idPairs: GenericIDPair[]): Promise<string> {
     const result = await this.doRequest<string>({
       path: `/data/${dashboardID}/${widgetID}`,
       method: "DELETE",
       params: {
-        ids: `${variableID}:${deviceID}`,
+        ids: idPairs,
       },
     });
 


### PR DESCRIPTION
## What does PR do?

Fix regression in `deleteData` method that made it only delete 1 record from 1 device.

Current version of SDK without reverting this will break Production. 

It's marked as breaking just to revert the breaking change.

## Type of alteration

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update
