### PR TITLE
chore: rename ProfileLimit type on profile list to ProfileWithLimit

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,8 +15,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "22.x"
+          registry-url: "https://registry.npmjs.org"
       - run: npm ci
       - run: npm publish --provenance --access public
         env:
@@ -30,7 +30,9 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      - run: npx jsr publish
+      - run: |
+          npm ci
+          npx jsr publish
   docs:
     name: "Build Docs/Types and Deploy"
     runs-on: ubuntu-latest

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@tago-io/sdk",
-  "version": "12.2.0",
+  "version": "12.2.1",
   "description": "TagoIO SDK for JavaScript in the browser and Node.js",
   "license": "Apache-2.0",
   "repository": "https://github.com/tago-io/sdk-js.git",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tago-io/sdk",
-  "version": "12.1.4",
+  "version": "12.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tago-io/sdk",
-      "version": "12.1.4",
+      "version": "12.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "nanoid": "5.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tago-io/sdk",
-  "version": "12.2.0",
+  "version": "12.2.1",
   "description": "TagoIO SDK for JavaScript in the browser and Node.js",
   "author": "TagoIO Inc.",
   "homepage": "https://tago.io",

--- a/src/infrastructure/envParams.ts
+++ b/src/infrastructure/envParams.ts
@@ -1,1 +1,1 @@
-export const version = "12.2.0";
+export const version = "12.2.1";

--- a/src/modules/Resources/plan.types.ts
+++ b/src/modules/Resources/plan.types.ts
@@ -18,7 +18,7 @@ interface PlanInfo extends PlanSetInfo {
   next_plan: string;
 }
 
-interface ProfileLimit {
+interface ProfileWithLimit {
   id: GenericID;
   name: string;
   limits: {
@@ -39,7 +39,7 @@ interface Discount {
 }
 
 interface Summary {
-  profiles: ProfileLimit[];
+  profiles: ProfileWithLimit[];
   plan: string;
   discounts: Discount[];
 }
@@ -60,4 +60,4 @@ interface CurrentPrices {
   addons: { name: string; price: number }[];
 }
 
-export type { PlanSetInfo, PlanInfo, ProfileLimit, Discount, Summary, Price, CurrentPrices };
+export type { PlanSetInfo, PlanInfo, ProfileWithLimit, Discount, Summary, Price, CurrentPrices };


### PR DESCRIPTION
## What does PR do?

- Type use on the Summary list of profiles was renamed from `ProfileLimit` to `ProfileWithLimit`, since it's a summarized profile WITH limit information
- Try to fix workflow for JSR publish

## Type of alteration

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
