### PR TITLE
Add TDeploy support for PDF service and Analysis info method

### DIFF
--- a/src/modules/Analysis/Analysis.ts
+++ b/src/modules/Analysis/Analysis.ts
@@ -3,7 +3,7 @@ import TagoIOModule from "../../common/TagoIOModule.ts";
 import { openSSEListening } from "../../infrastructure/apiSSE.ts";
 import getRegionObj, { setRuntimeRegion } from "../../regions.ts";
 import ConsoleService from "../Services/Console.ts";
-import type { AnalysisConstructorParams, AnalysisEnvironment, analysisFunction } from "./analysis.types.ts";
+import type { AnalysisConstructorParams, AnalysisEnvironment, analysisFunction, AnalysisItem } from "./analysis.types.ts";
 
 /**
  * Analysis execution context for TagoIO
@@ -210,6 +210,15 @@ class Analysis extends TagoIOModule<AnalysisConstructorParams> {
     }
 
     return new Analysis(analysis, params);
+  }
+
+  public async info(): Promise<AnalysisItem>  {
+    const result = await this.doRequest<AnalysisItem>({
+      path: "/info",
+      method: "GET",
+    });
+
+    return result;
   }
 }
 

--- a/src/modules/Analysis/analysis.types.ts
+++ b/src/modules/Analysis/analysis.types.ts
@@ -1,4 +1,5 @@
 import type { Regions, RegionsObj } from "../../regions.ts";
+import type { GenericID } from "../../common/common.types.ts";
 
 type analysisFunction = (context: any, data: any) => any;
 
@@ -24,6 +25,13 @@ interface AnalysisConstructorParams {
   loadEnvOnProcess?: boolean;
 }
 
+interface AnalysisItem {
+  id: GenericID;
+  name: string;
+  run_on: "tago" | "external";
+  active: boolean;
+}
+
 interface AnalysisEnvironment {
   [key: string]: string;
 }
@@ -40,4 +48,4 @@ interface TagoContext {
   log: (...args: any[]) => void;
 }
 
-export type { AnalysisConstructorParams, analysisFunction, AnalysisEnvironment, TagoContext };
+export type { AnalysisConstructorParams, analysisFunction, AnalysisEnvironment, TagoContext, AnalysisItem };

--- a/src/modules/Services/PDF.ts
+++ b/src/modules/Services/PDF.ts
@@ -1,4 +1,5 @@
 import TagoIOModule, { type GenericModuleParams } from "../../common/TagoIOModule.ts";
+import { getTDeployRegion } from "../../regions.ts";
 
 interface PDFResult {
   status: boolean;
@@ -92,7 +93,9 @@ class PDFService extends TagoIOModule<GenericModuleParams> {
    */
   public async generate(params: PDFParams): Promise<PDFResult> {
     try {
-      const response = await fetch("https://pdf.middleware.tago.io", {
+      const tdeploy = getTDeployRegion(this.params.region);
+      const pdfUri = tdeploy ? `https://pdf.${tdeploy}.tagoio.net` : "https://pdf.middleware.tago.io";
+      const response = await fetch(pdfUri, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/src/regions.ts
+++ b/src/regions.ts
@@ -55,7 +55,7 @@ let runtimeRegion: RegionsObj | undefined;
 /**
  * Extracts TDeploy region configuration if present
  * @param region Region configuration
- * @returns RegionsObj with TDeploy endpoints or undefined
+ * @returns TDeploy id or undefined
  */
 function getTDeployRegion(region?: Regions | RegionsObj): string {
   if (region && typeof region === "object" && "tdeploy" in region && region.tdeploy) {

--- a/src/regions.ts
+++ b/src/regions.ts
@@ -53,20 +53,30 @@ const regionsDefinition: Record<string, RegionsObjApi | undefined> = {
 let runtimeRegion: RegionsObj | undefined;
 
 /**
+ * Extracts TDeploy region configuration if present
+ * @param region Region configuration
+ * @returns RegionsObj with TDeploy endpoints or undefined
+ */
+function getTDeployRegion(region?: Regions | RegionsObj): string {
+  if (region && typeof region === "object" && "tdeploy" in region && region.tdeploy) {
+    return region.tdeploy.trim();
+  }
+  return undefined;
+}
+
+/**
  * Get connection URI for Realtime and API
  * @internal
  * @param region Region
  */
 function getConnectionURI(region?: Regions | RegionsObj): RegionsObj {
   // Handle tdeploy in RegionsObj - takes precedence
-  if (region && typeof region === "object" && "tdeploy" in region && region.tdeploy) {
-    const tdeploy = region.tdeploy.trim();
-    if (tdeploy) {
-      return {
+  const tdeploy = getTDeployRegion(region);
+  if (tdeploy) {
+    return {
         api: `https://api.${tdeploy}.tagoio.net`,
         sse: `https://sse.${tdeploy}.tagoio.net/events`,
       };
-    }
   }
 
   let normalizedRegion = region;
@@ -138,4 +148,4 @@ function setRuntimeRegion(region: RegionsObj): void {
 
 export default getConnectionURI;
 export type { Regions, RegionsObj };
-export { regionsDefinition, setRuntimeRegion };
+export { regionsDefinition, setRuntimeRegion, getTDeployRegion };


### PR DESCRIPTION
## Problem
- PDF service was hardcoded to use production endpoints, not supporting TDeploy regions
- Analysis class lacked a public method to retrieve analysis metadata (name, ID, status, run location)
- TDeploy region validation logic was duplicated in codebase

## Investigation
- Found TDeploy validation code inline in `getConnectionURI()` that could be reused
- Analysis internally used `/info` endpoint but didn't expose it publicly
- PDF service needed dynamic endpoint resolution based on region configuration

## Solution
- Extracted `getTDeployRegion()` as reusable utility function in regions module
- Added public `info()` method to Analysis class with proper `AnalysisItem` type
- Integrated TDeploy region support in PDF service for dynamic endpoint selection

## Changes
- **Analysis**: New `info()` method returns analysis metadata
- **PDF Service**: Dynamic endpoint resolution based on region (TDeploy or production)
- **Regions**: Exported `getTDeployRegion()` utility for reuse across services