### PR TITLE
Deprecate services.mqtt.publish()

### DIFF
--- a/src/modules/Services/MQTT.ts
+++ b/src/modules/Services/MQTT.ts
@@ -26,9 +26,17 @@ interface MQTTDataDeprecated extends Omit<MQTTData, "device"> {
 class MQTT extends TagoIOModule<GenericModuleParams> {
   /**
    * Publish MQTT
+   * @deprecated Legacy MQTT is deprecated. Use the new MQTT connector or HTTP API instead.
+   * See: https://docs.tago.io/docs/tagoio/integrations/networks/mqtt/
    * @param mqtt MQTT Object
    */
   public async publish(mqtt: MQTTData | MQTTDataDeprecated): Promise<string> {
+    console.warn(
+      "[TagoIO SDK] DEPRECATION: services.mqtt.publish() is deprecated and will be removed in a future major version. " +
+        "Migrate to the new MQTT connector or use the HTTP API. " +
+        "See: https://docs.tago.io/docs/tagoio/integrations/networks/mqtt/"
+    );
+
     let device: GenericID;
     if ("device" in mqtt) {
       device = mqtt.device;

--- a/src/modules/Services/MQTT.ts
+++ b/src/modules/Services/MQTT.ts
@@ -26,15 +26,12 @@ interface MQTTDataDeprecated extends Omit<MQTTData, "device"> {
 class MQTT extends TagoIOModule<GenericModuleParams> {
   /**
    * Publish MQTT
-   * @deprecated Legacy MQTT is deprecated. Use the new MQTT connector or HTTP API instead.
-   * See: https://docs.tago.io/docs/tagoio/integrations/networks/mqtt/
+   * @deprecated Migrate to TagoTIP: https://docs.tago.io/docs/tagotip/transports/mqtt
    * @param mqtt MQTT Object
    */
   public async publish(mqtt: MQTTData | MQTTDataDeprecated): Promise<string> {
     console.warn(
-      "[TagoIO SDK] DEPRECATION: services.mqtt.publish() is deprecated and will be removed in a future major version. " +
-        "Migrate to the new MQTT connector or use the HTTP API. " +
-        "See: https://docs.tago.io/docs/tagoio/integrations/networks/mqtt/"
+      "[TagoIO SDK] services.mqtt.publish() is deprecated. Migrate to TagoTIP: https://docs.tago.io/docs/tagotip/transports/mqtt"
     );
 
     let device: GenericID;

--- a/src/modules/Services/Services.ts
+++ b/src/modules/Services/Services.ts
@@ -103,7 +103,17 @@ class Services extends TagoIOModule<GenericModuleParams> {
 
   /** @internal @deprecated renamed to .mqtt (lowercase) */
   public MQTT: MQTT = new MQTT(this.params);
+  /**
+   * @deprecated Legacy MQTT is deprecated and will be removed in a future major version.
+   * Migrate to the new MQTT connector or use the HTTP API.
+   * See: https://docs.tago.io/docs/tagoio/integrations/networks/mqtt/
+   */
   public mqtt: MQTT = new MQTT(this.params);
+  /**
+   * @deprecated Legacy MQTT is deprecated and will be removed in a future major version.
+   * Migrate to the new MQTT connector or use the HTTP API.
+   * See: https://docs.tago.io/docs/tagoio/integrations/networks/mqtt/
+   */
   static get mqtt(): MQTT {
     return new Services().mqtt;
   }

--- a/src/modules/Services/Services.ts
+++ b/src/modules/Services/Services.ts
@@ -103,17 +103,9 @@ class Services extends TagoIOModule<GenericModuleParams> {
 
   /** @internal @deprecated renamed to .mqtt (lowercase) */
   public MQTT: MQTT = new MQTT(this.params);
-  /**
-   * @deprecated Legacy MQTT is deprecated and will be removed in a future major version.
-   * Migrate to the new MQTT connector or use the HTTP API.
-   * See: https://docs.tago.io/docs/tagoio/integrations/networks/mqtt/
-   */
+  /** @deprecated Migrate to TagoTIP: https://docs.tago.io/docs/tagotip/transports/mqtt */
   public mqtt: MQTT = new MQTT(this.params);
-  /**
-   * @deprecated Legacy MQTT is deprecated and will be removed in a future major version.
-   * Migrate to the new MQTT connector or use the HTTP API.
-   * See: https://docs.tago.io/docs/tagoio/integrations/networks/mqtt/
-   */
+  /** @deprecated Migrate to TagoTIP: https://docs.tago.io/docs/tagotip/transports/mqtt */
   static get mqtt(): MQTT {
     return new Services().mqtt;
   }


### PR DESCRIPTION
## Summary

- Adds `@deprecated` JSDoc annotation to `Services.MQTT.publish()`
- Adds a runtime `console.warn` deprecation notice when the method is called
- Points users to the new MQTT connector and HTTP API as alternatives

Legacy MQTT is being phased out. This change gives SDK consumers a heads-up before the method is removed in a future major version.

## Test plan

- [ ] `npm run build` passes
- [ ] Calling `services.mqtt.publish()` emits a deprecation warning to the console
- [ ] Existing functionality remains unchanged (the request still goes through)