### PR TITLE
feat/notification-trigger-scope

### DIFF
--- a/src/modules/Resources/notifications.types.ts
+++ b/src/modules/Resources/notifications.types.ts
@@ -1,7 +1,9 @@
-import type { GenericID, Query } from "../../common/common.types.ts";
+import type { Data, GenericID, Query } from "../../common/common.types.ts";
+import type { DeviceListScope, UserListScope } from "../../types.ts";
 
 interface NotificationTriggerAnalysis {
   analysis_id: GenericID;
+  scope: Data[] | UserListScope[] | DeviceListScope[];
 }
 interface NotificationTriggerHTTP {
   url: string;


### PR DESCRIPTION
## What does PR do?

Adds a `scope` field to the `NotificationTriggerAnalysis` type so notification triggers fired by an analysis can carry the originating entity (data, user list, or device list) along with the `analysis_id`.

This makes the type accurate to the payload the platform already sends and lets consumers branch on the scope without an extra lookup.

### Ticket.

- [feat: Enhance Push Notification Button Triggers](https://github.com/tago-io/issues/issues/29)