### PR TITLE
Update Analysis RunTypeOptions to new runtime identifiers

### DIFF
--- a/src/common/common.types.ts
+++ b/src/common/common.types.ts
@@ -147,7 +147,7 @@ type ExportOption = "csv" | "json" | "xml";
 
 type Conditionals = "<" | ">" | "=" | "!" | "><" | "*";
 
-type RunTypeOptions = "node" | "python";
+type RunTypeOptions = "node-legacy" | "python-legacy" | "node-rt2025" | "python-rt2025" | "deno-rt2025" | "other";
 
 type TokenCreateResponse = { token: GenericToken; expire_date: ExpireTimeOption; permission: PermissionOption };
 

--- a/src/modules/Resources/Analyses.ts
+++ b/src/modules/Resources/Analyses.ts
@@ -82,7 +82,7 @@ class Analyses extends TagoIOModule<GenericModuleParams> {
    * ```typescript
    * const newAnalysis = await Resources.analysis.create({
    *   name: "My Analysis",
-   *   type: "node",
+   *   runtime: "node-rt2025",
    *   tags: [{ key: "type", value: "data-processing" }]
    * });
    * console.log(newAnalysis.id, newAnalysis.token); // analysis-id-123, analysis-token-123
@@ -228,7 +228,7 @@ class Analyses extends TagoIOModule<GenericModuleParams> {
    * const result = await Resources.analysis.uploadScript("analysis-id-123", {
    *   name: "script.js",
    *   content: "base64-encoded-content",
-   *   language: "node"
+   *   language: "node-rt2025"
    * });
    * console.log(result);
    * ```


### PR DESCRIPTION
## Summary

Ports the change from #167 (merged into `master`) to `main`, where it was missing. `main` is the default branch, so the updated runtime identifiers need to land here too.

Updates the Analysis `RunTypeOptions` type to reflect the platform's new runtime identifiers.

## Changes

- Replaces the old `node` / `python` values with `node-legacy`, `python-legacy`, `node-rt2025`, `python-rt2025`, `deno-rt2025`, and `other`. The type is consumed by the `language` and `runtime` fields in `AnalysisCreateInfo` / `ScriptFile`, so the change propagates automatically.
- Fixes two JSDoc examples in `Analyses.ts` that still used the removed values, and corrects the wrong field in the `create` example (`type` -> `runtime`).

## Note

`RunTypeOptions` and `SnippetRuntime` now have nearly identical values (only `other` differs). Unification left for a future improvement.

## Risk (CIA)

Likelihood: 🟢 Low | Impact: 🟢 Low | Exposure: 🟢 Low