### PR TITLE
Add hybrid device type and mutable_variable_regex field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tago-io/sdk",
-  "version": "12.2.4",
+  "version": "12.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tago-io/sdk",
-      "version": "12.2.4",
+      "version": "12.2.5",
       "license": "Apache-2.0",
       "dependencies": {
         "nanoid": "5.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tago-io/sdk",
-  "version": "12.2.4",
+  "version": "12.2.5",
   "description": "TagoIO SDK for JavaScript in the browser and Node.js",
   "author": "TagoIO Inc.",
   "homepage": "https://tago.io",

--- a/src/modules/Resources/buckets.types.ts
+++ b/src/modules/Resources/buckets.types.ts
@@ -25,7 +25,7 @@ interface BucketCreateInfo {
 /**
  * Type of data storage for a device (bucket).
  */
-type DataStorageType = "immutable" | "mutable" | "legacy";
+type DataStorageType = "immutable" | "mutable" | "legacy" | "hybrid";
 type ChunkPeriod = "day" | "week" | "month" | "quarter";
 interface BucketInfoBasic extends BucketCreateInfo {
   id: GenericID;
@@ -55,6 +55,28 @@ type BucketInfoImmutable = Omit<BucketInfoBasic, "data_retention" | "data_retent
    */
   chunk_retention: number;
 };
+type BucketInfoHybrid = Omit<BucketInfoBasic, "data_retention" | "data_retention_ignore"> & {
+  type: "hybrid";
+  /**
+   * Chunk division to retain data in the device.
+   *
+   * Always returned for Hybrid devices.
+   */
+  chunk_period: ChunkPeriod;
+  /**
+   * Amount of chunks to retain data according to the `chunk_period`.
+   *
+   * Always returned for Hybrid devices.
+   */
+  chunk_retention: number;
+  /**
+   * Regex that routes each variable to the mutable side at insert time (unanchored
+   * substring match).
+   *
+   * Always returned for Hybrid devices.
+   */
+  mutable_variable_regex: string;
+};
 type BucketInfoMutable = Omit<
   BucketInfoBasic,
   "chunk_period" | "chunk_retention" | "data_retention" | "data_retention_ignore"
@@ -70,7 +92,7 @@ type BucketInfoLegacy = Omit<BucketInfoBasic, "chunk_period" | "chunk_retention"
   data_retention_ignore: [];
 };
 
-type BucketInfo = BucketInfoImmutable | BucketInfoMutable | BucketInfoLegacy;
+type BucketInfo = BucketInfoImmutable | BucketInfoMutable | BucketInfoLegacy | BucketInfoHybrid;
 
 interface BucketDeviceInfo {
   id: GenericID;

--- a/src/modules/Resources/buckets.types.ts
+++ b/src/modules/Resources/buckets.types.ts
@@ -71,7 +71,8 @@ type BucketInfoHybrid = Omit<BucketInfoBasic, "data_retention" | "data_retention
   chunk_retention: number;
   /**
    * Regex that routes each variable to the mutable side at insert time (unanchored
-   * substring match).
+   * substring match). It must not match every variable or no variable; use a mutable or
+   * immutable device for those cases.
    *
    * Always returned for Hybrid devices.
    */

--- a/src/modules/Resources/devices.types.ts
+++ b/src/modules/Resources/devices.types.ts
@@ -111,7 +111,25 @@ type DeviceCreateInfo =
   | DeviceCreateInfoMutable
   | DeviceCreateInfoImmutable
   | DeviceCreateInfoHybrid;
-type DeviceEditInfo = Partial<Omit<DeviceCreateInfo, "chunk_period" | "type"> & { chunk_retention: number }>;
+type DeviceEditInfo = Partial<
+  Omit<DeviceCreateInfo, "chunk_period" | "type"> & {
+    chunk_retention: number;
+    /**
+     * Regex that routes each variable to the mutable side at insert time (Hybrid devices
+     * only). Can only be changed while the device is empty.
+     */
+    mutable_variable_regex: string;
+  }
+>;
+
+interface DeviceEmptyParams {
+  /**
+   * For Hybrid devices only: empty a single side of the device instead of everything.
+   * `"mutable"` truncates the editable variables; `"immutable"` drops the telemetry chunks.
+   * Omit to remove all data (every device type).
+   */
+  route?: "mutable" | "immutable";
+}
 
 interface DeviceInfoBase {
   /** Device ID. */
@@ -299,6 +317,7 @@ interface DeviceChunkCopyResponse {
 
 export type {
   DeviceQuery,
+  DeviceEmptyParams,
   DeviceCreateInfo,
   ConfigurationParams,
   DeviceInfo,

--- a/src/modules/Resources/devices.types.ts
+++ b/src/modules/Resources/devices.types.ts
@@ -94,8 +94,9 @@ interface DeviceCreateInfoHybrid extends Omit<DeviceCreateInfoBasic, "type"> {
 
   /**
    * Regex that routes each variable to the mutable side at insert time (unanchored
-   * substring match). Required for Hybrid devices. Can only be changed while the device
-   * is empty.
+   * substring match). It must not match every variable or no variable; use a mutable or
+   * immutable device for those cases. Required for Hybrid devices. Can only be changed
+   * while the device is empty.
    */
   mutable_variable_regex: string;
 }

--- a/src/modules/Resources/devices.types.ts
+++ b/src/modules/Resources/devices.types.ts
@@ -69,12 +69,47 @@ interface DeviceCreateInfoImmutable extends Omit<DeviceCreateInfoBasic, "type"> 
   chunk_retention: number;
 }
 /**
+ * Hybrid devices combine immutable telemetry (time-partitioned, with retention via
+ * `chunk_period` + `chunk_retention`) and editable mutable variables (no retention) in
+ * a single device. At insert time each variable is routed to the mutable side when it
+ * matches `mutable_variable_regex`, otherwise it is stored as immutable telemetry.
+ */
+interface DeviceCreateInfoHybrid extends Omit<DeviceCreateInfoBasic, "type"> {
+  type: "hybrid";
+
+  /**
+   * Chunk division to retain data in the device.
+   *
+   * Required for Hybrid devices.
+   */
+  chunk_period: "day" | "week" | "month" | "quarter";
+
+  /**
+   * Amount of chunks to retain data according to the `chunk_period`.
+   * Integer between in the range of 0 to 36 (inclusive).
+   *
+   * Required for Hybrid devices.
+   */
+  chunk_retention: number;
+
+  /**
+   * Regex that routes each variable to the mutable side at insert time (unanchored
+   * substring match). Required for Hybrid devices. Can only be changed while the device
+   * is empty.
+   */
+  mutable_variable_regex: string;
+}
+/**
  * @deprecated
  */
 interface DeviceCreateInfoLegacy extends Omit<DeviceCreateInfoBasic, "type"> {
   type: "legacy";
 }
-type DeviceCreateInfo = DeviceCreateInfoLegacy | DeviceCreateInfoMutable | DeviceCreateInfoImmutable;
+type DeviceCreateInfo =
+  | DeviceCreateInfoLegacy
+  | DeviceCreateInfoMutable
+  | DeviceCreateInfoImmutable
+  | DeviceCreateInfoHybrid;
 type DeviceEditInfo = Partial<Omit<DeviceCreateInfo, "chunk_period" | "type"> & { chunk_retention: number }>;
 
 interface DeviceInfoBase {
@@ -124,7 +159,12 @@ type DeviceInfoMutable = Required<
     Omit<DeviceCreateInfoMutable, "configuration_params" | "serie_number" | "connector_parse" | "parse_function">
 >;
 
-type DeviceInfo = DeviceInfoImmutable | DeviceInfoMutable;
+type DeviceInfoHybrid = Required<
+  DeviceInfoBase &
+    Omit<DeviceCreateInfoHybrid, "configuration_params" | "serie_number" | "connector_parse" | "parse_function">
+>;
+
+type DeviceInfo = DeviceInfoImmutable | DeviceInfoMutable | DeviceInfoHybrid;
 
 interface ConfigurationParams {
   sent: boolean;


### PR DESCRIPTION
## Summary
Adds the `hybrid` device storage type and its `mutable_variable_regex` field to the device create/edit/info types (and the `DataStorageType` union), matching backend tago-io/server#1644. Hybrid combines immutable telemetry (chunked, with retention) and editable mutable variables in one device, routed per-variable by the regex.

## Changes
- `DeviceCreateInfoHybrid` added to the `DeviceCreateInfo` union; `DeviceInfoHybrid` added to `DeviceInfo`; `mutable_variable_regex` editable via `DeviceEditInfo`.
- `"hybrid"` added to `DataStorageType` (+ `BucketInfoHybrid` if applicable).
- `emptyDeviceData(deviceId, params?)` accepts `{ route: "mutable" | "immutable" }` on hybrid devices to empty a single side (mutable: editable variables; immutable: telemetry chunks); omitting it keeps the whole-device behavior for every type.
- Fixed `DeviceEditInfo` dropping `mutable_variable_regex`: `Omit` over the create union keeps only keys common to all members, so the field was not actually editable as typed; it is now added explicitly (same treatment `chunk_retention` already had).
- Documented that `mutable_variable_regex` rejects match-everything / match-nothing patterns (the server rejects `.*`, `^$`, etc.; use a mutable or immutable device for those cases).

## Test plan
- [x] `npm run check` (Biome) clean
- [x] `npm run build` succeeds (type-checks)
- [x] `vitest run` — 419 tests pass

## Risk (CIA)
Likelihood: 🟢 Low | Impact: 🟢 Low | Exposure: 🟢 Low
Additive type definitions; no runtime behavior change.

## Related
- Backend: tago-io/server#1644
- Docs: tago-io/docs#108

