### PR TITLE
CI: publish npm with OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,10 +17,10 @@ jobs:
         with:
           node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
+      # Trusted publishing needs npm >= 11.5.1 (OIDC). Do not set NODE_AUTH_TOKEN on publish.
+      - run: npm install -g npm@latest
       - run: npm ci
-      - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm publish --access public
 
   publish-jsr:
     name: "Publish to JSR"


### PR DESCRIPTION
## Summary
Switch npm publish in GitHub Actions to OIDC trusted publishing. Remove `NODE_AUTH_TOKEN` / `NPM_TOKEN` from the publish step (it blocks OIDC), install a current npm CLI, and drop the explicit `--provenance` flag because trusted publishing generates provenance automatically.

## Why
`v12.2.5` failed on npm with `E404` on `PUT @tago-io/sdk` while still using `secrets.NPM_TOKEN`. JSR already published for that release. npm Trusted Publisher is configured for `tago-io/sdk-js` + `publish.yml`; the workflow must match that model.

## Test plan
- [ ] Confirm Trusted Publisher on npmjs.com for `@tago-io/sdk`: org `tago-io`, repo `sdk-js`, workflow `publish.yml`, empty environment
- [ ] Do not enable "disallow tokens" until one OIDC publish succeeds
- [ ] Merge this PR to `main`
- [ ] Re-publish: cut a new release (or re-run only after the release tag includes this workflow). Tag-bound release runs use the workflow on that tag, so re-running the `v12.2.5` job alone will not pick up this change
- [ ] Confirm npm shows `@tago-io/sdk` at the new version with a provenance attestation
- [ ] Confirm JSR still publishes on the same release

## Risk (CIA)
Likelihood: 🟢 Low | Impact: 🟡 Medium | Exposure: 🟢 Low

> [!WARNING]
> Impact is Medium because a bad OIDC/workflow match blocks all automated npm releases until fixed. Scope is CI auth only; package code is unchanged.