### PR TITLE
CI: fix npm OIDC publish with Node 24, drop npm@latest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,12 +13,14 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+      # Node 24 ships npm >= 11.5.1 (required for OIDC trusted publishing).
+      # Do not run npm install -g npm@latest: it can break bundled deps (e.g. sigstore).
+      # Do not set NODE_AUTH_TOKEN: OIDC must win over a placeholder token from setup-node.
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
-      # Trusted publishing needs npm >= 11.5.1 (OIDC). Do not set NODE_AUTH_TOKEN on publish.
-      - run: npm install -g npm@latest
+          package-manager-cache: false
       - run: npm ci
       - run: npm publish --access public
 


### PR DESCRIPTION
## Summary
Stop upgrading npm with `npm install -g npm@latest` on the publish job. That install left a broken CLI (`Cannot find module 'sigstore'`) on the `v12.2.6` release. Use Node 24 instead so the runner ships npm 11.x (required for OIDC trusted publishing) without a global reinstall.

## Why
`v12.2.6` npm job failed immediately on `npm publish` after the global upgrade. Node 22 only bundles npm 10.9.x, which is below the 11.5.1 trusted-publishing floor, so we need a newer Node rather than `npm@latest`.

## Test plan
- [ ] Confirm Trusted Publisher on npmjs.com still points at `tago-io` / `sdk-js` / `publish.yml`
- [ ] Merge this PR to `main`
- [ ] Cut a new release (or otherwise publish from a commit that includes this workflow). Re-running the `v12.2.6` job alone will not pick up this file from the old tag
- [ ] Confirm the publish job logs show Node 24 and npm >= 11.5.1
- [ ] Confirm `@tago-io/sdk` appears on npm with provenance
- [ ] Confirm JSR still publishes on the same release

## Risk (CIA)
Likelihood: 🟢 Low | Impact: 🟡 Medium | Exposure: 🟢 Low

> [!WARNING]
> Impact is Medium because release CI remains the only automated path to npm. Scope is publish tooling only; package runtime is unchanged.