### PR TITLE
Release: bump SDK version to 12.2.7

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@tago-io/sdk",
-  "version": "12.2.6",
+  "version": "12.2.7",
   "description": "TagoIO SDK for JavaScript in the browser and Node.js",
   "license": "Apache-2.0",
   "repository": "https://github.com/tago-io/sdk-js.git",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tago-io/sdk",
-  "version": "12.2.6",
+  "version": "12.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tago-io/sdk",
-      "version": "12.2.6",
+      "version": "12.2.7",
       "license": "Apache-2.0",
       "dependencies": {
         "nanoid": "5.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tago-io/sdk",
-  "version": "12.2.6",
+  "version": "12.2.7",
   "description": "TagoIO SDK for JavaScript in the browser and Node.js",
   "author": "TagoIO Inc.",
   "homepage": "https://tago.io",


### PR DESCRIPTION
## Summary
Bump the package version to `12.2.7` in `package.json`, `package-lock.json`, and `deno.json` so the next release can publish to both npm and JSR. `12.2.6` is already on JSR; npm is still at `12.2.4` after the failed OIDC publishes.

## Test plan
- [ ] Diff shows only version fields (package.json, package-lock.json, deno.json)
- [ ] After merge, cut GitHub release `v12.2.7` with the fixed publish workflow from main
- [ ] Confirm npm receives `@tago-io/sdk@12.2.7` with provenance
- [ ] Confirm JSR receives `@tago-io/sdk@12.2.7`

## Risk (CIA)
Likelihood: 🟢 Low | Impact: 🟢 Low | Exposure: 🟢 Low