### PR TITLE
CI: fix publish run annotations (action upgrades)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,11 +12,11 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       # Node 24 ships npm >= 11.5.1 (required for OIDC trusted publishing).
       # Do not run npm install -g npm@latest: it can break bundled deps (e.g. sigstore).
       # Do not set NODE_AUTH_TOKEN: OIDC must win over a placeholder token from setup-node.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
@@ -31,7 +31,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: |
           npm ci
           npx jsr publish
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [publish-npm]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,8 @@ jobs:
     name: "Build Docs/Types and Deploy"
     runs-on: ubuntu-latest
     needs: [publish-npm]
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
@@ -12,9 +12,9 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,9 @@ name: Units Tests
 
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary
Clear the warnings from the `v12.2.7` publish run by upgrading GitHub Actions, fixing an unused OS matrix entry, and adding explicit `permissions` blocks for CodeQL.

Annotations from [run 28978916748](https://github.com/tago-io/sdk-js/actions/runs/28978916748):

| Annotation | Cause | Fix |
|---|---|---|
| `Unexpected input(s) 'package-manager-cache'` (x2) | `package-manager-cache` exists only on `actions/setup-node@v6+`; we used `@v4` | `setup-node@v6` |
| Node.js 20 deprecated for `actions/checkout@v4` / `setup-node@v4` | Those action majors still declare a Node 20 runtime; runner forces Node 24 | `checkout@v6`, `setup-node@v6` |
| CodeQL: workflow does not contain permissions | Unit tests and docs job had no `permissions` block | `contents: read` on tests; `contents: write` on docs (gh-pages push) |

Also set `runs-on: ${{ matrix.os }}` in unit tests. The matrix listed windows/macOS but always ran on Ubuntu.

## Test plan
- [ ] PR CI: Units Tests matrix runs on ubuntu, windows, and macos for node 20/22/24
- [ ] No `package-manager-cache` or Node 20 action-runtime annotations on unit-test jobs
- [ ] CodeQL no longer flags missing permissions on these workflows
- [ ] Next release: Publish workflow has no those annotations on npm/JSR/docs jobs

## Risk (CIA)
Likelihood: 🟢 Low | Impact: 🟢 Low | Exposure: 🟢 Low