### PR TITLE
Add SQL resource for TagoSQL stored queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tago-io/sdk",
-  "version": "12.2.7",
+  "version": "12.2.8",
   "description": "TagoIO SDK for JavaScript in the browser and Node.js",
   "author": "TagoIO Inc.",
   "homepage": "https://tago.io",

--- a/src/infrastructure/envParams.ts
+++ b/src/infrastructure/envParams.ts
@@ -1,1 +1,1 @@
-export const version = "12.2.7";
+export const version = "12.2.8";

--- a/src/modules/Resources/Resources.ts
+++ b/src/modules/Resources/Resources.ts
@@ -18,6 +18,7 @@ import Plan from "./Plan.ts";
 import Profile from "./Profile.ts";
 import Run from "./Run.ts";
 import Secrets from "./Secrets.ts";
+import SQL from "./SQL.ts";
 import ServiceAuthorization from "./ServiceAuthorization.ts";
 import TagoCores from "./TagoCores.ts";
 import Tags from "./Tags.ts";
@@ -178,6 +179,11 @@ class Resources extends TagoIOModule<GenericModuleParams> {
   public secrets: Secrets = new Secrets(this.params);
   static get secrets(): Secrets {
     return new Resources().secrets;
+  }
+
+  public sql: SQL = new SQL(this.params);
+  static get sql(): SQL {
+    return new Resources().sql;
   }
 
   public entities: Entities = new Entities(this.params);

--- a/src/modules/Resources/SQL.test.ts
+++ b/src/modules/Resources/SQL.test.ts
@@ -8,6 +8,7 @@ const QUERY_ROW = {
   id: "sql-id-123",
   name: "Latest temperature",
   tags: [{ key: "audience", value: "dashboard" }],
+  session_context: true,
   created_at: "2026-07-01T12:00:00.000Z",
   updated_at: "2026-07-02T12:00:00.000Z",
 };
@@ -32,6 +33,16 @@ const server = setupServer(
       result: {
         tables: [{ function: "device", label: "Device Data", columns: [] }],
         resources: { devices: [], entities: [] },
+        functions: [
+          { name: "count", kind: "aggregate", args: ["column"], description: "Row count" },
+          {
+            name: "session_user_tag",
+            kind: "session",
+            args: ["key"],
+            description: "The executing user's value for a tag key, filled by the server",
+            example: "COALESCE(session_user_tag('key'), '...')",
+          },
+        ],
       },
     })
   ),
@@ -63,6 +74,7 @@ describe("SQL resource", () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe("sql-id-123");
+    expect(result[0].session_context).toBe(true);
     expect(result[0].created_at).toBeInstanceOf(Date);
   });
 
@@ -80,6 +92,7 @@ describe("SQL resource", () => {
     const result = await sql.info("sql-id-123");
 
     expect(result.name).toBe("Latest temperature");
+    expect(result.session_context).toBe(true);
     expect(result.updated_at).toBeInstanceOf(Date);
   });
 
@@ -116,5 +129,8 @@ describe("SQL resource", () => {
     const result = await sql.tables({ filter: "sensor" });
 
     expect(result.tables[0].function).toBe("device");
+    expect(result.functions[0].name).toBe("count");
+    expect(result.functions[1].kind).toBe("session");
+    expect(result.functions[1].example).toContain("COALESCE");
   });
 });

--- a/src/modules/Resources/SQL.test.ts
+++ b/src/modules/Resources/SQL.test.ts
@@ -1,0 +1,129 @@
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import SQL from "./SQL.ts";
+
+const QUERY_ROW = {
+  id: "sql-id-123",
+  name: "Latest temperature",
+  tags: [{ key: "audience", value: "dashboard" }],
+  created_at: "2026-07-01T12:00:00.000Z",
+  updated_at: "2026-07-02T12:00:00.000Z",
+};
+
+const EXECUTE_RESULT = {
+  columns: [
+    { name: "variable", type: "string" },
+    { name: "value", type: "number" },
+  ],
+  rows: [{ variable: "temperature", value: 41.2 }],
+  row_count: 1,
+  execution_ms: 12,
+  served_from_cache: false,
+};
+
+const server = setupServer(
+  http.get("https://api.tago.io/sql", () => HttpResponse.json({ status: true, result: [QUERY_ROW] })),
+  http.post("https://api.tago.io/sql", () => HttpResponse.json({ status: true, result: QUERY_ROW })),
+  http.get("https://api.tago.io/sql/tables", () =>
+    HttpResponse.json({
+      status: true,
+      result: {
+        tables: [{ function: "device", label: "Device Data", columns: [] }],
+        resources: { devices: [], entities: [] },
+      },
+    })
+  ),
+  http.post("https://api.tago.io/sql/execute", () => HttpResponse.json({ status: true, result: EXECUTE_RESULT })),
+  http.get("https://api.tago.io/sql/sql-id-123", () => HttpResponse.json({ status: true, result: QUERY_ROW })),
+  http.put("https://api.tago.io/sql/sql-id-123", () => HttpResponse.json({ status: true, result: QUERY_ROW })),
+  http.delete("https://api.tago.io/sql/sql-id-123", () =>
+    HttpResponse.json({ status: true, result: { id: "sql-id-123" } })
+  ),
+  http.get("https://api.tago.io/sql/sql-id-123/version/1", () =>
+    HttpResponse.json({
+      status: true,
+      result: { query: "SELECT 1", params: [], created_at: "2026-07-01T12:00:00.000Z" },
+    })
+  ),
+  http.post("https://api.tago.io/sql/sql-id-123/execute", () =>
+    HttpResponse.json({ status: true, result: EXECUTE_RESULT })
+  )
+);
+
+const sql = new SQL({ token: "test-token" });
+
+describe("SQL resource", () => {
+  beforeAll(() => server.listen());
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  it("lists queries and parses dates", async () => {
+    const result = await sql.list({ fields: ["id", "name", "tags"] });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("sql-id-123");
+    expect(result[0].created_at).toBeInstanceOf(Date);
+  });
+
+  it("creates a query", async () => {
+    const result = await sql.create({
+      name: "Latest temperature",
+      query: "SELECT variable, value FROM device($1) AS d LIMIT 10",
+      params: [{ key: "$1", value: "my-device-id" }],
+    });
+
+    expect(result.id).toBe("sql-id-123");
+  });
+
+  it("fetches query info", async () => {
+    const result = await sql.info("sql-id-123");
+
+    expect(result.name).toBe("Latest temperature");
+    expect(result.updated_at).toBeInstanceOf(Date);
+  });
+
+  it("edits a query", async () => {
+    const result = await sql.edit("sql-id-123", {
+      name: "Latest temperature",
+      query: "SELECT 1",
+    });
+
+    expect(result.id).toBe("sql-id-123");
+  });
+
+  it("deletes a query", async () => {
+    const result = await sql.delete("sql-id-123");
+
+    expect(result).toEqual({ id: "sql-id-123" });
+  });
+
+  it("fetches a version snapshot", async () => {
+    const result = await sql.getVersion("sql-id-123", 1);
+
+    expect(result.query).toBe("SELECT 1");
+    expect(result.created_at).toBeInstanceOf(Date);
+  });
+
+  it("executes a stored query", async () => {
+    const result = await sql.execute("sql-id-123", { params: [{ key: "$1", value: "my-device-id" }] });
+
+    expect(result.row_count).toBe(1);
+    expect(result.served_from_cache).toBe(false);
+  });
+
+  it("executes an ad-hoc query", async () => {
+    const result = await sql.executeAdhoc("SELECT variable, value FROM device($1) AS d LIMIT 10", [
+      { key: "$1", value: "my-device-id" },
+    ]);
+
+    expect(result.rows[0].variable).toBe("temperature");
+  });
+
+  it("fetches the tables catalog", async () => {
+    const result = await sql.tables({ filter: "sensor" });
+
+    expect(result.tables[0].function).toBe("device");
+  });
+});

--- a/src/modules/Resources/SQL.test.ts
+++ b/src/modules/Resources/SQL.test.ts
@@ -35,7 +35,6 @@ const server = setupServer(
       },
     })
   ),
-  http.post("https://api.tago.io/sql/execute", () => HttpResponse.json({ status: true, result: EXECUTE_RESULT })),
   http.get("https://api.tago.io/sql/sql-id-123", () => HttpResponse.json({ status: true, result: QUERY_ROW })),
   http.put("https://api.tago.io/sql/sql-id-123", () => HttpResponse.json({ status: true, result: QUERY_ROW })),
   http.delete("https://api.tago.io/sql/sql-id-123", () =>
@@ -111,14 +110,6 @@ describe("SQL resource", () => {
 
     expect(result.row_count).toBe(1);
     expect(result.served_from_cache).toBe(false);
-  });
-
-  it("executes an ad-hoc query", async () => {
-    const result = await sql.executeAdhoc("SELECT variable, value FROM device($1) AS d LIMIT 10", [
-      { key: "$1", value: "my-device-id" },
-    ]);
-
-    expect(result.rows[0].variable).toBe("temperature");
   });
 
   it("fetches the tables catalog", async () => {

--- a/src/modules/Resources/SQL.ts
+++ b/src/modules/Resources/SQL.ts
@@ -1,0 +1,245 @@
+import type { GenericID } from "../../common/common.types.ts";
+import TagoIOModule, { type GenericModuleParams } from "../../common/TagoIOModule.ts";
+import { Cache } from "../../modules.ts";
+import dateParser from "../Utils/dateParser.ts";
+import type {
+  SQLCreateInfo,
+  SQLExecuteObj,
+  SQLExecuteResult,
+  SQLInfo,
+  SQLParam,
+  SQLQuery,
+  SQLTablesQuery,
+  SQLTablesResult,
+  SQLVersionInfo,
+} from "./sql.types.ts";
+
+class SQL extends TagoIOModule<GenericModuleParams> {
+  /**
+   * Lists all TagoSQL queries from your profile with pagination support.
+   *
+   * @see {@link https://docs.tago.io/docs/tagoio/tagosql/queries} TagoSQL Queries
+   *
+   * @example
+   * If receive an error "Authorization Denied", check policy **SQL Query** / **Access** in Access Management.
+   * ```typescript
+   * const result = await Resources.sql.list({
+   *   page: 1,
+   *   fields: ["id", "name", "tags"],
+   *   amount: 20,
+   * });
+   * console.log(result); // [ { id: 'query-id-123', name: 'My query', tags: [] } ]
+   * ```
+   */
+  public async list(queryObj?: SQLQuery): Promise<SQLInfo[]> {
+    let result = await this.doRequest<SQLInfo[]>({
+      path: "/sql",
+      method: "GET",
+      params: {
+        page: queryObj?.page || 1,
+        fields: queryObj?.fields || ["id", "name", "tags"],
+        filter: queryObj?.filter || {},
+        amount: queryObj?.amount || 20,
+        orderBy: queryObj?.orderBy ? `${queryObj.orderBy[0]},${queryObj.orderBy[1]}` : "created_at,desc",
+      },
+    });
+
+    result = result.map((data) => dateParser(data, ["created_at", "updated_at"]));
+
+    return result;
+  }
+
+  /**
+   * Creates a new TagoSQL query on your profile.
+   *
+   * @see {@link https://docs.tago.io/docs/tagoio/tagosql/queries} TagoSQL Queries
+   *
+   * @example
+   * ```typescript
+   * const result = await Resources.sql.create({
+   *   name: "Latest temperature",
+   *   query: "SELECT variable, value, time FROM device($1) AS d WHERE variable = 'temperature' ORDER BY time DESC LIMIT 10",
+   *   params: [{ key: "$1", value: "my-device-id" }],
+   * });
+   * console.log(result); // { id: 'query-id-123', name: 'Latest temperature', ... }
+   * ```
+   */
+  public async create(sqlObj: SQLCreateInfo): Promise<SQLInfo> {
+    const result = await this.doRequest<SQLInfo>({
+      path: "/sql",
+      method: "POST",
+      body: sqlObj,
+    });
+
+    Cache.clearCache();
+
+    return dateParser(result, ["created_at", "updated_at"]);
+  }
+
+  /**
+   * Retrieves detailed information about a specific TagoSQL query.
+   *
+   * @see {@link https://docs.tago.io/docs/tagoio/tagosql/queries} TagoSQL Queries
+   *
+   * @example
+   * If receive an error "Authorization Denied", check policy **SQL Query** / **Access** in Access Management.
+   * ```typescript
+   * const result = await Resources.sql.info("query-id-123");
+   * console.log(result); // { id: 'query-id-123', name: 'My query', query: 'SELECT ...', ... }
+   * ```
+   */
+  public async info(sqlID: GenericID): Promise<SQLInfo> {
+    const result = await this.doRequest<SQLInfo>({
+      path: `/sql/${sqlID}`,
+      method: "GET",
+    });
+
+    return dateParser(result, ["created_at", "updated_at"]);
+  }
+
+  /**
+   * Replaces a TagoSQL query. The query is re-validated and its cached results are
+   * dropped; a new version is stored when the query or the params change.
+   *
+   * @see {@link https://docs.tago.io/docs/tagoio/tagosql/queries} TagoSQL Queries
+   *
+   * @example
+   * ```typescript
+   * const result = await Resources.sql.edit("query-id-123", {
+   *   name: "Latest temperature",
+   *   query: "SELECT variable, value, time FROM device($1) AS d ORDER BY time DESC LIMIT 20",
+   *   params: [{ key: "$1", value: "my-device-id" }],
+   * });
+   * console.log(result); // { id: 'query-id-123', version: 2, ... }
+   * ```
+   */
+  public async edit(sqlID: GenericID, sqlObj: SQLCreateInfo): Promise<SQLInfo> {
+    const result = await this.doRequest<SQLInfo>({
+      path: `/sql/${sqlID}`,
+      method: "PUT",
+      body: sqlObj,
+    });
+
+    Cache.clearCache();
+
+    return dateParser(result, ["created_at", "updated_at"]);
+  }
+
+  /**
+   * Deletes a TagoSQL query from your profile.
+   *
+   * @see {@link https://docs.tago.io/docs/tagoio/tagosql/queries} TagoSQL Queries
+   *
+   * @example
+   * ```typescript
+   * const result = await Resources.sql.delete("query-id-123");
+   * console.log(result); // { id: 'query-id-123' }
+   * ```
+   */
+  public async delete(sqlID: GenericID): Promise<{ id: GenericID }> {
+    const result = await this.doRequest<{ id: GenericID }>({
+      path: `/sql/${sqlID}`,
+      method: "DELETE",
+    });
+
+    Cache.clearCache();
+
+    return result;
+  }
+
+  /**
+   * Retrieves a historical snapshot (query and params) of a TagoSQL query.
+   * To restore it, send the snapshot's query and params back with `edit`.
+   *
+   * @see {@link https://docs.tago.io/docs/tagoio/tagosql/queries} TagoSQL Queries
+   *
+   * @example
+   * ```typescript
+   * const result = await Resources.sql.getVersion("query-id-123", 1);
+   * console.log(result); // { query: 'SELECT ...', params: [], created_at: ... }
+   * ```
+   */
+  public async getVersion(sqlID: GenericID, version: number): Promise<SQLVersionInfo> {
+    const result = await this.doRequest<SQLVersionInfo>({
+      path: `/sql/${sqlID}/version/${version}`,
+      method: "GET",
+    });
+
+    return dateParser(result, ["created_at"]);
+  }
+
+  /**
+   * Executes a TagoSQL query. Params sent here override the saved defaults per key;
+   * `test: true` skips the result cache entirely.
+   *
+   * @see {@link https://docs.tago.io/docs/tagoio/tagosql/executing-queries} Executing Queries
+   *
+   * @example
+   * If receive an error "Authorization Denied", check policy **SQL Query** / **Execute** in Access Management.
+   * ```typescript
+   * const result = await Resources.sql.execute("query-id-123", {
+   *   params: [{ key: "$1", value: "my-device-id" }],
+   * });
+   * console.log(result); // { columns: [...], rows: [...], row_count: 1, ... }
+   * ```
+   */
+  public async execute(sqlID: GenericID, executeObj?: SQLExecuteObj): Promise<SQLExecuteResult> {
+    const result = await this.doRequest<SQLExecuteResult>({
+      path: `/sql/${sqlID}/execute`,
+      method: "POST",
+      body: executeObj || {},
+    });
+
+    return result;
+  }
+
+  /**
+   * Runs a one-off TagoSQL query without storing it. Profile token only; results are
+   * never cached. Store queries you run regularly with `create`.
+   *
+   * @see {@link https://docs.tago.io/docs/tagoio/tagosql/executing-queries} Executing Queries
+   *
+   * @example
+   * ```typescript
+   * const result = await Resources.sql.executeAdhoc(
+   *   "SELECT variable, value FROM device($1) AS d WHERE value > $2 LIMIT 10",
+   *   [{ key: "$1", value: "my-device-id" }, { key: "$2", value: "25" }]
+   * );
+   * console.log(result); // { columns: [...], rows: [...], row_count: 3, ... }
+   * ```
+   */
+  public async executeAdhoc(query: string, params?: SQLParam[]): Promise<SQLExecuteResult> {
+    const result = await this.doRequest<SQLExecuteResult>({
+      path: "/sql/execute",
+      method: "POST",
+      body: { query, params: params || [] },
+    });
+
+    return result;
+  }
+
+  /**
+   * Retrieves the TagoSQL schema discovery catalog: the virtual table families with
+   * their typed columns, plus your devices and entities. Pass `entity_id` to resolve
+   * one entity's columns.
+   *
+   * @see {@link https://docs.tago.io/docs/tagoio/tagosql/tables} Available Tables
+   *
+   * @example
+   * ```typescript
+   * const result = await Resources.sql.tables({ filter: "sensor", amount: 20 });
+   * console.log(result); // { tables: [...], resources: { devices: [...], entities: [...] } }
+   * ```
+   */
+  public async tables(queryObj?: SQLTablesQuery): Promise<SQLTablesResult> {
+    const result = await this.doRequest<SQLTablesResult>({
+      path: "/sql/tables",
+      method: "GET",
+      params: queryObj || {},
+    });
+
+    return result;
+  }
+}
+
+export default SQL;

--- a/src/modules/Resources/SQL.ts
+++ b/src/modules/Resources/SQL.ts
@@ -7,7 +7,6 @@ import type {
   SQLExecuteObj,
   SQLExecuteResult,
   SQLInfo,
-  SQLParam,
   SQLQuery,
   SQLTablesQuery,
   SQLTablesResult,
@@ -188,31 +187,6 @@ class SQL extends TagoIOModule<GenericModuleParams> {
       path: `/sql/${sqlID}/execute`,
       method: "POST",
       body: executeObj || {},
-    });
-
-    return result;
-  }
-
-  /**
-   * Runs a one-off TagoSQL query without storing it. Profile token only; results are
-   * never cached. Store queries you run regularly with `create`.
-   *
-   * @see {@link https://docs.tago.io/docs/tagoio/tagosql/executing-queries} Executing Queries
-   *
-   * @example
-   * ```typescript
-   * const result = await Resources.sql.executeAdhoc(
-   *   "SELECT variable, value FROM device($1) AS d WHERE value > $2 LIMIT 10",
-   *   [{ key: "$1", value: "my-device-id" }, { key: "$2", value: "25" }]
-   * );
-   * console.log(result); // { columns: [...], rows: [...], row_count: 3, ... }
-   * ```
-   */
-  public async executeAdhoc(query: string, params?: SQLParam[]): Promise<SQLExecuteResult> {
-    const result = await this.doRequest<SQLExecuteResult>({
-      path: "/sql/execute",
-      method: "POST",
-      body: { query, params: params || [] },
     });
 
     return result;

--- a/src/modules/Resources/sql.types.ts
+++ b/src/modules/Resources/sql.types.ts
@@ -1,0 +1,116 @@
+import type { GenericID, Query, TagsObj } from "../../common/common.types.ts";
+
+/** Positional parameter as `{ key: "$n", value: "..." }`. */
+interface SQLParam {
+  key: string;
+  value: string;
+}
+
+interface SQLCreateInfo {
+  /** Required, 1..=64 chars. */
+  name: string;
+  /** Optional, up to 1024 chars. */
+  description?: string;
+  /** The TagoSQL query. Parsed and validated against your plan at save time. */
+  query: string;
+  /** Positional defaults; must cover exactly the placeholders the query uses ($1..$N). */
+  params?: SQLParam[];
+  /** Enables the result cache on execute. Default false. */
+  cache_enabled?: boolean;
+  /** Clamped to 0..=86400 (24h). A TTL of 0 disables caching. */
+  cache_ttl_seconds?: number;
+  /** Per-query soft rate cap; rejected at save time if above the plan's hard cap. */
+  rate_limit_rpm?: number | null;
+  /** An inactive query cannot be executed. Default true. */
+  active?: boolean;
+  tags?: TagsObj[];
+}
+
+interface SQLInfo extends SQLCreateInfo {
+  id: GenericID;
+  version: number;
+  created_at: Date;
+  updated_at: Date;
+}
+
+type SQLQuery = Query<SQLInfo, "name" | "active" | "created_at" | "updated_at">;
+
+interface SQLExecuteObj {
+  /** Values merged over the saved defaults per key. */
+  params?: SQLParam[];
+  /** Probe mode: skips the result cache entirely (no read, no write). */
+  test?: boolean;
+  /** Fleet pagination cursor: the last device id of the previous page. */
+  after_device?: GenericID;
+}
+
+interface SQLColumn {
+  name: string;
+  type: "string" | "number" | "timestamp" | "boolean" | "json";
+}
+
+interface SQLExecuteResult {
+  /** Ordered column list with client-facing types. */
+  columns: SQLColumn[];
+  /** One object per row, keyed by column name. */
+  rows: Record<string, unknown>[];
+  row_count: number;
+  /** Server-side execution time in milliseconds. */
+  execution_ms: number;
+  /** True when the result came from the cache. */
+  served_from_cache: boolean;
+}
+
+interface SQLVersionInfo {
+  query: string;
+  params: SQLParam[];
+  created_at: Date | null;
+}
+
+interface SQLTableInfo {
+  function: string;
+  label: string;
+  tag_form?: string;
+  columns: SQLColumn[];
+  /** True for entity data when no entity_id was supplied to resolve columns. */
+  dynamic?: boolean;
+}
+
+interface SQLResourceItem {
+  id: GenericID;
+  name: string;
+}
+
+interface SQLTablesResult {
+  tables: SQLTableInfo[];
+  resources: {
+    devices: SQLResourceItem[];
+    entities: SQLResourceItem[];
+  };
+}
+
+interface SQLTablesQuery {
+  /** Substring match on device/entity name. */
+  filter?: string;
+  /** Default 20, clamped 1..=100. */
+  amount?: number;
+  /** 1-based. */
+  page?: number;
+  /** Resolve the columns of one entity you own. */
+  entity_id?: GenericID;
+}
+
+export type {
+  SQLColumn,
+  SQLCreateInfo,
+  SQLExecuteObj,
+  SQLExecuteResult,
+  SQLInfo,
+  SQLParam,
+  SQLQuery,
+  SQLResourceItem,
+  SQLTableInfo,
+  SQLTablesQuery,
+  SQLTablesResult,
+  SQLVersionInfo,
+};

--- a/src/modules/Resources/sql.types.ts
+++ b/src/modules/Resources/sql.types.ts
@@ -31,6 +31,8 @@ interface SQLInfo extends SQLCreateInfo {
   version: number;
   created_at: Date;
   updated_at: Date;
+  /** Read-only, derived server-side: true when the query text uses session functions. Never accepted as input. */
+  session_context: boolean;
 }
 
 type SQLQuery = Query<SQLInfo, "name" | "active" | "created_at" | "updated_at">;
@@ -81,12 +83,23 @@ interface SQLResourceItem {
   name: string;
 }
 
+interface SQLFunctionInfo {
+  name: string;
+  kind: "aggregate" | "session";
+  args: string[];
+  description: string;
+  /** Present only on session functions; carries the COALESCE authoring idiom. */
+  example?: string;
+}
+
 interface SQLTablesResult {
   tables: SQLTableInfo[];
   resources: {
     devices: SQLResourceItem[];
     entities: SQLResourceItem[];
   };
+  /** Everything callable in a query, built from the allowlists. */
+  functions: SQLFunctionInfo[];
 }
 
 interface SQLTablesQuery {
@@ -105,6 +118,7 @@ export type {
   SQLCreateInfo,
   SQLExecuteObj,
   SQLExecuteResult,
+  SQLFunctionInfo,
   SQLInfo,
   SQLParam,
   SQLQuery,

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,7 @@ export type {
   TokenCreateResponse as ServiceAuthTokenCreateResponse,
 } from "./modules/Resources/ServiceAuthorization.types.ts";
 export * from "./modules/Resources/secrets.type.ts";
+export * from "./modules/Resources/sql.types.ts";
 export * from "./modules/Resources/tagocore.types.ts";
 export * from "./modules/Resources/template.types.ts";
 export * from "./modules/RunUser/runUser.types.ts";


### PR DESCRIPTION
## Summary
TagoSQL shipped in server v10.3.0 with no SDK coverage, so applications and analyses had to call the /sql routes with raw fetch. This adds a `sql` resource to `Resources` covering stored-query CRUD (`list`, `create`, `info`, `edit`, `delete`), version snapshots (`getVersion`), execution (`execute` with per-key param overrides and test mode), and schema discovery (`tables`). The legacy `/sql/eval` endpoint and the removed ad-hoc `POST /sql/execute` route (tago-io/server#1688) are intentionally not covered.

Stored-query info/list responses now expose a read-only, server-derived `session_context` boolean (true when the query text uses session functions; never accepted as input), and the `tables` catalog gains a `functions` array (`SQLFunctionInfo`: `name`, `kind`, `args`, `description`, and `example` on session entries) listing everything callable in a query (tago-io/server#1690).

## Test plan
- [ ] Vitest: `src/modules/Resources/SQL.test.ts` (msw-mocked round trips for all methods, date parsing on list/info/version)
- [ ] `pnpm run check`, `pnpm run build`, and `pnpm test` pass (56 files / 428 tests)
- [ ] Method signatures and wire shapes verified against the server contract in `docs/TagoSQL.md` (params as `[{key, value}]` arrays, execute envelope with `served_from_cache`, list fields allowlist)

## Risk (CIA)
Likelihood: 🟢 Low | Impact: 🟢 Low | Exposure: 🟢 Low
