### PR TITLE
Fix JSR publish failing on Deno Blob type check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tago-io/sdk",
-  "version": "12.2.8",
+  "version": "12.2.9",
   "description": "TagoIO SDK for JavaScript in the browser and Node.js",
   "author": "TagoIO Inc.",
   "homepage": "https://tago.io",

--- a/src/infrastructure/envParams.ts
+++ b/src/infrastructure/envParams.ts
@@ -1,1 +1,1 @@
-export const version = "12.2.8";
+export const version = "12.2.9";

--- a/src/modules/Resources/Files.ts
+++ b/src/modules/Resources/Files.ts
@@ -517,7 +517,7 @@ class Files extends TagoIOModule<GenericModuleParams> {
     const uploadID = await this.createMultipartUpload(filename, options);
 
     const bytesPerChunk = options?.chunkSize || 7 * MB;
-    const fileBlob = file instanceof Blob ? file : new Blob([file]);
+    const fileBlob = file instanceof Blob ? file : new Blob([file as Uint8Array<ArrayBuffer>]);
     const chunkAmount = Math.floor(fileBlob.size / bytesPerChunk) + 1;
     const partsPerTime = 3;
 


### PR DESCRIPTION
## Summary
JSR publish fails Deno's type check in `uploadFile`: `BufferLike` is a `Uint8Array` backed by `ArrayBufferLike`, and Deno's `Blob` constructor only accepts views over a plain `ArrayBuffer` (TS2322 at `src/modules/Resources/Files.ts:520`). Cast the buffer at the `Blob` construction boundary, keeping the public API accepting Node Buffers. Bumps the version to 12.2.9 so both npm and JSR ship a new patch.

## Test plan
- [x] `deno publish --dry-run --set-version 12.2.9` passes locally (reproduced the TS2322 failure before the fix)
- [x] `pnpm run check` (oxlint + oxfmt)
- [x] `pnpm test` (427 tests passing)
- [x] `pnpm run build` plus CJS/ESM smoke test on `lib/modules.cjs` and `lib/modules.js`

## Risk (CIA)
Likelihood: 🟢 Low | Impact: 🟢 Low | Exposure: 🟢 Low
