### PR TITLE
Restrict SQL list fields typing to the projection allowlist

### DIFF
--- a/src/modules/Resources/sql.types.ts
+++ b/src/modules/Resources/sql.types.ts
@@ -35,7 +35,11 @@ interface SQLInfo extends SQLCreateInfo {
   session_context: boolean;
 }
 
-type SQLQuery = Query<SQLInfo, "name" | "active" | "created_at" | "updated_at">;
+// ? List projection allowlist: other row fields come from info() only.
+type SQLListField = "id" | "name" | "tags" | "active" | "created_at" | "updated_at";
+type SQLQuery = Omit<Query<SQLInfo, "name" | "active" | "created_at" | "updated_at">, "fields"> & {
+  fields?: SQLListField[];
+};
 
 interface SQLExecuteObj {
   /** Values merged over the saved defaults per key. */


### PR DESCRIPTION
## Summary
Restricts the SQL list `fields` typing to the projection allowlist shipped by tago-io/server#1692: `id`, `name`, `tags`, `active`, `created_at`, `updated_at`. Other row fields (`query`, `params`, `description`, cache settings, `session_context`) are info-only on the API, so projecting them from the list now returns a 400; the types should stop offering them.

## Test plan
- [x] Full test suite green after the change

## Risk (CIA)
Likelihood: 🟢 Low | Impact: 🟢 Low | Exposure: 🟢 Low

## Related
- tago-io/server#1692
