### PR TITLE
Fix WidgetData variables and query typings

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,6 @@
 {
   "name": "@tago-io/sdk",
+  "version": "12.3.0",
   "description": "TagoIO SDK for JavaScript in the browser and Node.js",
   "license": "Apache-2.0",
   "repository": "https://github.com/tago-io/sdk-js.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tago-io/sdk",
-  "version": "12.2.9",
+  "version": "12.3.0",
   "description": "TagoIO SDK for JavaScript in the browser and Node.js",
   "author": "TagoIO Inc.",
   "homepage": "https://tago.io",

--- a/src/modules/Resources/dashboards.types.ts
+++ b/src/modules/Resources/dashboards.types.ts
@@ -64,9 +64,19 @@ interface WidgetData {
   origin: GenericID;
   qty?: number;
   timezone?: string;
-  variables?: string;
+  variables?: string[];
   bucket?: GenericID;
-  query?: "min" | "max" | "count" | "avg" | "sum";
+  query?:
+    | "min"
+    | "max"
+    | "count"
+    | "avg"
+    | "sum"
+    | "last_value"
+    | "last_item"
+    | "last_insert"
+    | "aggregate"
+    | "conditional";
   start_date?: Date | string;
   end_date?: Date | string;
   overwrite?: boolean;


### PR DESCRIPTION
Closes https://github.com/tago-io/issues/issues/913

## Summary

- `WidgetData.variables` is now `string[]` instead of `string`, matching the API contract (the API rejects a plain string with "Expected array, received string").
- `WidgetData.query` now also accepts `"last_value"`, `"last_item"`, `"last_insert"`, `"aggregate"`, and `"conditional"`, which are all supported by the API data providers.

## Test plan

- `pnpm run check` (oxlint + oxfmt) passes.
- `TZ=UTC pnpm test` — 427 tests pass.
- Values verified against the server: widget schema validates `variables` as `z.array(z.string())`, and the bucket data providers implement `last_value`/`last_item`/`last_insert` plus the `aggregate`/`conditional` query refinements.