### PR TITLE
TagoTiP service for sending device commands

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@tago-io/sdk",
-  "version": "12.3.0",
+  "version": "12.3.1",
   "description": "TagoIO SDK for JavaScript in the browser and Node.js",
   "license": "Apache-2.0",
   "repository": "https://github.com/tago-io/sdk-js.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tago-io/sdk",
-  "version": "12.3.0",
+  "version": "12.3.1",
   "description": "TagoIO SDK for JavaScript in the browser and Node.js",
   "author": "TagoIO Inc.",
   "homepage": "https://tago.io",

--- a/src/modules/Services/Services.ts
+++ b/src/modules/Services/Services.ts
@@ -9,6 +9,7 @@ import PDFService from "./PDF.ts";
 import Sendgrid from "./Sendgrid.ts";
 import SMS from "./SMS.ts";
 import SMTP from "./SMTP.ts";
+import TagoTiP from "./TagoTiP.ts";
 import TwilioWhatsapp from "./Twilio-Whatsapp.ts";
 import Twilio from "./Twillio.ts";
 
@@ -99,6 +100,11 @@ class Services extends TagoIOModule<GenericModuleParams> {
   public twilio_whatsapp: TwilioWhatsapp = new TwilioWhatsapp(this.params);
   static get twilio_whatsapp(): TwilioWhatsapp {
     return new Services().twilio_whatsapp;
+  }
+
+  public tagotip: TagoTiP = new TagoTiP(this.params);
+  static get tagotip(): TagoTiP {
+    return new Services().tagotip;
   }
 
   /** @internal @deprecated renamed to .mqtt (lowercase) */

--- a/src/modules/Services/TagoTiP.ts
+++ b/src/modules/Services/TagoTiP.ts
@@ -1,0 +1,49 @@
+import TagoIOModule, { type GenericModuleParams } from "../../common/TagoIOModule.ts";
+
+interface TagoTiPCommand {
+  /** Serial of the target device */
+  serial: string;
+  /** Protocol used to deliver the command */
+  protocol: string;
+  /** Command payload sent to the device */
+  body: string;
+}
+
+class TagoTiP extends TagoIOModule<GenericModuleParams> {
+  /**
+   * Send a command to a device through TagoTiP.
+   *
+   * Requires a Service Authorization token in the module `token`.
+   *
+   * @param command Command object with serial, protocol and body
+   *
+   * @example
+   * ```ts
+   * import { Services } from "@tago-io/sdk";
+   *
+   * const services = new Services({ token: "your-service-authorization-token" });
+   *
+   * await services.tagotip.cmd({
+   *   serial: "mqtt1",
+   *   protocol: "mqtt",
+   *   body: "reboot-now",
+   * });
+   * ```
+   */
+  public async cmd(command: TagoTiPCommand): Promise<string> {
+    const result = await this.doRequest<string>({
+      path: "/tip/cmd",
+      method: "POST",
+      body: {
+        serial: command.serial,
+        protocol: command.protocol,
+        body: command.body,
+      },
+    });
+
+    return result;
+  }
+}
+
+export default TagoTiP;
+export type { TagoTiPCommand };


### PR DESCRIPTION
## Summary
Add a `TagoTiP` service that sends device commands through TagoTiP. Exposed as `services.tagotip.cmd({ serial, protocol, body })`, it wraps `POST /tip/cmd` using a Service Authorization token from the module `token`.

## Test plan
- [x] `pnpm run check` (oxlint + oxfmt) passes
- [x] `pnpm run build` produces dual ESM/CJS with valid isolated declarations
- [x] Manual: ran `services.tagotip.cmd({ serial: "mqtt1", protocol: "mqtt", body: "reboot-now" })` against the beta API, response `{"status":"ok"}`, matching the equivalent raw curl

## Risk (CIA)
Likelihood: 🟢 Low | Impact: 🟢 Low | Exposure: 🟢 Low
Additive change; new service method, no existing behavior touched.