### PR TITLE
Fix sql.list ignoring the fields parameter

### DIFF
--- a/src/modules/Resources/SQL.test.ts
+++ b/src/modules/Resources/SQL.test.ts
@@ -78,6 +78,24 @@ describe("SQL resource", () => {
     expect(result[0].created_at).toBeInstanceOf(Date);
   });
 
+  it("sends fields as the repeated `fields[]` form the endpoint requires", async () => {
+    let requestUrl = "";
+    server.use(
+      http.get("https://api.tago.io/sql", ({ request }) => {
+        requestUrl = request.url;
+        return HttpResponse.json({ status: true, result: [QUERY_ROW] });
+      })
+    );
+
+    await sql.list({ fields: ["id", "name", "tags", "active", "created_at", "updated_at"], amount: 10 });
+
+    // ? The indexed form (`fields[0]=id`) is silently ignored by /sql, which then returns only id/name/tags.
+    const params = new URL(requestUrl).searchParams;
+    expect(params.getAll("fields[]")).toEqual(["id", "name", "tags", "active", "created_at", "updated_at"]);
+    expect(params.get("fields[0]")).toBeNull();
+    expect(params.get("amount")).toBe("10");
+  });
+
   it("creates a query", async () => {
     const result = await sql.create({
       name: "Latest temperature",

--- a/src/modules/Resources/SQL.ts
+++ b/src/modules/Resources/SQL.ts
@@ -1,3 +1,4 @@
+import qs from "qs";
 import type { GenericID } from "../../common/common.types.ts";
 import TagoIOModule, { type GenericModuleParams } from "../../common/TagoIOModule.ts";
 import { Cache } from "../../modules.ts";
@@ -31,12 +32,16 @@ class SQL extends TagoIOModule<GenericModuleParams> {
    * ```
    */
   public async list(queryObj?: SQLQuery): Promise<SQLInfo[]> {
+    // ? /sql only parses the `fields[]=x` array form; the default `fields[0]=x` is ignored and the
+    // ? endpoint falls back to id/name/tags. Encoded on the path so other modules keep their format.
+    const fields = queryObj?.fields || ["id", "name", "tags"];
+    const fieldsQuery = qs.stringify({ fields }, { arrayFormat: "brackets" });
+
     let result = await this.doRequest<SQLInfo[]>({
-      path: "/sql",
+      path: `/sql?${fieldsQuery}`,
       method: "GET",
       params: {
         page: queryObj?.page || 1,
-        fields: queryObj?.fields || ["id", "name", "tags"],
         filter: queryObj?.filter || {},
         amount: queryObj?.amount || 20,
         orderBy: queryObj?.orderBy ? `${queryObj.orderBy[0]},${queryObj.orderBy[1]}` : "created_at,desc",


### PR DESCRIPTION
## Summary
`sql.list` ignored the `fields` argument and always returned only `id`, `name`, and `tags`. The `/sql` endpoint parses only the repeated `fields[]=x` array form, while `qs` defaults to the indexed `fields[0]=x` form, so the endpoint discarded the projection and fell back to its own default.

## Why
The shared request layer serializes params with `qs.stringify(params)`, whose default `arrayFormat` is `indices`. Older endpoints such as `/device` accept both forms, so this never surfaced; `/sql` accepts only the bracket form and is the first module to expose the mismatch.

Changing the default in `buildUrl` would fix every module at once but rewrites the wire format of every SDK request, and existing `apiRequestFetch` tests pin the `tags[0]` form. The encoding is therefore scoped to `/sql` to avoid a regression elsewhere.

## Test plan
- [x] Regression test in `src/modules/Resources/SQL.test.ts` asserting the repeated `fields[]` form is sent and `fields[0]` is absent
- [x] Full suite: `pnpm test` — 427/427 passing, including the `apiRequestFetch` array-encoding tests that pin the indexed form for other modules
- [x] `pnpm exec oxlint --deny-warnings` and `oxfmt --check` clean on both changed files
- [x] Verified live against `api.us-e1.tago.io` with the same token, isolating only the array format:
  - `fields[0]=id&fields[1]=name...` returns `id, name, tags`
  - `fields[]=id&fields[]=name...` returns all six requested fields
- [x] Manual run through the SDK after the fix: `sql.list` with six fields returns all six, with `created_at`/`updated_at` parsed to `Date`

## Risk (CIA)
Likelihood: 🟢 Low | Impact: 🟢 Low | Exposure: 🟢 Low

## Related
Follow-up worth considering separately: switch `buildUrl` to `arrayFormat: "brackets"` SDK-wide. The bracket form is a superset accepted by the legacy endpoints (verified on `/device`, where a nested `filter[tags]` filter narrows 7 rows to 1 under both forms), so other endpoints may share this rigidity. That is a broad behavior change and belongs in its own PR with wider validation.
